### PR TITLE
Add image fallback helper and document manual asset uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+assets/img/*
+!assets/img/.gitkeep
+!assets/img/uploads/
+!assets/img/uploads/.gitkeep

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# pi
+# Pi Studio Pilates Web Platform
+
+Bu depo, Pi Studio Pilates stüdyosu için hazırlanan çok dilli altyapıya hazır modern web sitesi ve yönetim panelini içerir. Uygulama sade PHP ve MySQL kullanılarak geliştirilmiştir.
+
+## Özellikler
+
+- Hero, ekipmanlar, eğitmen bilgisi, eğitimler, planlar, ders programı, S.S.S. ve iletişim bölümleriyle zengin ön yüz.
+- Yönetim paneli sayesinde tüm içerikleri güncelleme, yeni kayıt ekleme ve mesajları görüntüleme.
+- Güvenli oturum yönetimi, CSRF koruması ve bcrypt ile şifrelenmiş admin kullanıcı.
+- Google Maps gömme, WhatsApp kısa yolu ve SEO odaklı meta alanları.
+- Tüm görsel yolları kodda referans olarak bulunur ancak depoda herhangi bir görsel dosyası yer almaz.
+
+> Bu depoda resim dosyaları yoktur. assets/img klasörü boş bırakılmıştır. Resimleri siz FTP ile kendiniz yükleyeceksiniz. Admin panelinden yüklenen resimler assets/img/uploads klasörüne kaydedilecektir.
+
+## Kurulum
+
+1. Tüm projeyi XAMPP veya paylaşımlı hosting ortamınızda `htdocs/pistudio` klasörünün içine kopyalayın.
+2. `pistudio.sql` dosyasını phpMyAdmin üzerinden içe aktararak veritabanı tablolarını ve örnek içerikleri oluşturun.
+3. `config/config.php` dosyasındaki veritabanı bağlantı ayarlarını (sunucu, kullanıcı adı, şifre) ortamınıza göre güncelleyin.
+4. `assets/img/` klasörüne gerekli görselleri manuel olarak yükleyin. **Bu depoda resim dosyaları yoktur. `assets/img` klasörü boş bırakılmıştır. Resimleri siz FTP ile kendiniz yükleyeceksiniz. Admin panelinden yüklenen resimler `assets/img/uploads` klasörüne kaydedilecektir.** Kullanmanız
+   gereken dosya adları:
+   - `hero-bg.jpg`
+   - `equip-mat.jpg`
+   - `equip-reformer.jpg`
+   - `equip-tower.jpg`
+   - `equip-cadillac.jpg`
+   - `equip-chair.jpg`
+   - `equip-barrel.jpg`
+   - `history.jpg`
+   - `pinar.jpg`
+   - `placeholder.jpg`
+5. Admin paneline `https://alanadiniz.com/admin/login.php` adresinden giriş yapın.
+   - E-posta: `pinar@pistudiopilates.com`
+   - Şifre: `pistudio2025!`
+6. İhtiyaç halinde FTP veya sunucu yapılandırmasıyla web kökünü `public/` klasörüne yönlendirin.
+
+## Geliştirme
+
+- İçerik düzenlemeleri için yönetim panelinde ilgili bölümlerdeki formları kullanın.
+- Yeni görseller yüklediğinizde dosyalar otomatik olarak `assets/img/uploads/` altına kaydedilir.
+- Çok dillilik için `public/index.php` içinde gerekli metinler yönetim panelinden güncellenebilir. Opsiyonel olarak JSON tabanlı çeviri sistemi eklemek için `config/config.php` altında ek yapılandırmalar yapılabilir.
+
+## Komutlar
+
+- Yerel geliştirme için PHP yerleşik sunucusunu kullanabilirsiniz: `php -S localhost:8000 -t public`
+
+## Dağıtım
+
+- Üretim derlemesi gerekmez; `public/` klasörünü FTP ile sunucuya gönderin.
+- `assets/` klasörü ve `config/config.php` dahil olmak üzere tüm dosyaların sunucuda bulunduğundan emin olun.
+- Veritabanı yapılandırması tamamlandıktan sonra site ve admin paneli kullanıma hazırdır.
+
+## Lisans
+
+Bu proje Pi Studio Pilates için özelleştirilmiştir.

--- a/admin/content.php
+++ b/admin/content.php
@@ -1,0 +1,117 @@
+<?php
+require_once __DIR__ . '/header.php';
+
+$about = fetchOne('SELECT * FROM about_pilates LIMIT 1');
+$history = fetchOne('SELECT * FROM history LIMIT 1');
+$instructor = fetchOne('SELECT * FROM instructor LIMIT 1');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    validateCsrf($_POST['csrf_token'] ?? '');
+    $section = $_POST['section'] ?? '';
+
+    switch ($section) {
+        case 'about':
+            $content = trim($_POST['content'] ?? '');
+            if ($about) {
+                executeQuery('UPDATE about_pilates SET content = :content WHERE id = :id', [':content' => $content, ':id' => $about['id']]);
+            } else {
+                executeQuery('INSERT INTO about_pilates (content) VALUES (:content)', [':content' => $content]);
+            }
+            setFlash('success', 'Pilates Nedir? metni güncellendi.');
+            break;
+        case 'history':
+            $content = trim($_POST['content'] ?? '');
+            if ($history) {
+                executeQuery('UPDATE history SET content = :content WHERE id = :id', [':content' => $content, ':id' => $history['id']]);
+            } else {
+                executeQuery('INSERT INTO history (content) VALUES (:content)', [':content' => $content]);
+            }
+            setFlash('success', 'Tarihçe metni güncellendi.');
+            break;
+        case 'instructor':
+            $bio = trim($_POST['bio'] ?? '');
+            $highlights = trim($_POST['highlights'] ?? '');
+            try {
+                $photo = handleImageUpload($_FILES['photo'] ?? [], $instructor['photo'] ?? null);
+            } catch (RuntimeException $e) {
+                setFlash('error', $e->getMessage());
+                header('Location: content.php');
+                exit;
+            }
+            $params = [
+                ':name' => 'Pınar Sarı Koçak',
+                ':bio' => $bio,
+                ':highlights' => $highlights,
+            ];
+            if ($photo) {
+                $params[':photo'] = $photo;
+            }
+            if ($instructor) {
+                $query = 'UPDATE instructor SET name = :name, bio = :bio, highlights = :highlights';
+                if ($photo) {
+                    $query .= ', photo = :photo';
+                }
+                $query .= ' WHERE id = :id';
+                $params[':id'] = $instructor['id'];
+            } else {
+                $query = 'INSERT INTO instructor (name, bio, highlights, photo) VALUES (:name, :bio, :highlights, :photo)';
+                if (!$photo) {
+                    $params[':photo'] = null;
+                }
+            }
+            executeQuery($query, $params);
+            setFlash('success', 'Eğitmen bilgileri güncellendi.');
+            break;
+    }
+
+    header('Location: content.php');
+    exit;
+}
+
+$success = getFlash('success');
+$error = getFlash('error');
+?>
+<header>
+    <h1>Metin Yönetimi</h1>
+</header>
+<?php if ($success): ?><div class="flash"><?= htmlspecialchars($success); ?></div><?php endif; ?>
+<?php if ($error): ?><div class="alert error"><?= htmlspecialchars($error); ?></div><?php endif; ?>
+<div class="card">
+    <h3>Pilates Nedir?</h3>
+    <form method="post">
+        <textarea name="content" rows="6" required><?= htmlspecialchars($about['content'] ?? ''); ?></textarea>
+        <input type="hidden" name="section" value="about">
+        <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+        <button type="submit" class="btn primary">Kaydet</button>
+    </form>
+</div>
+
+<div class="card">
+    <h3>Kısaca Tarihçe</h3>
+    <form method="post">
+        <textarea name="content" rows="6" required><?= htmlspecialchars($history['content'] ?? ''); ?></textarea>
+        <input type="hidden" name="section" value="history">
+        <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+        <button type="submit" class="btn primary">Kaydet</button>
+    </form>
+</div>
+
+<div class="card">
+    <h3>Pınar Sarı Koçak</h3>
+    <form method="post" enctype="multipart/form-data">
+        <label for="bio">Özgeçmiş</label>
+        <textarea name="bio" id="bio" rows="6" required><?= htmlspecialchars($instructor['bio'] ?? ''); ?></textarea>
+        <label for="highlights">Uzmanlıklar (her satıra bir madde)</label>
+        <textarea name="highlights" id="highlights" rows="5"><?= htmlspecialchars($instructor['highlights'] ?? ''); ?></textarea>
+        <label for="photo">Fotoğraf</label>
+        <input type="file" name="photo" id="photo" accept="image/*">
+        <?php if (!empty($instructor['photo'])): ?>
+            <p>Mevcut fotoğraf: <strong><?= htmlspecialchars($instructor['photo']); ?></strong></p>
+        <?php endif; ?>
+        <input type="hidden" name="section" value="instructor">
+        <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+        <button type="submit" class="btn primary">Kaydet</button>
+    </form>
+</div>
+<?php
+require_once __DIR__ . '/layout-footer.php';

--- a/admin/equipments.php
+++ b/admin/equipments.php
@@ -1,0 +1,145 @@
+<?php
+require_once __DIR__ . '/header.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    validateCsrf($_POST['csrf_token'] ?? '');
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'delete') {
+        $id = (int)($_POST['id'] ?? 0);
+        $equipment = fetchOne('SELECT * FROM equipments WHERE id = :id', [':id' => $id]);
+        if ($equipment) {
+            if (!empty($equipment['img']) && file_exists(UPLOAD_DIR . $equipment['img'])) {
+                @unlink(UPLOAD_DIR . $equipment['img']);
+            }
+            executeQuery('DELETE FROM equipments WHERE id = :id', [':id' => $id]);
+            setFlash('success', 'Ekipman silindi.');
+        }
+        header('Location: equipments.php');
+        exit;
+    }
+
+    $title = trim($_POST['title'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $moreInfo = trim($_POST['more_info'] ?? '');
+    $sortOrder = (int)($_POST['sort_order'] ?? 0);
+    $id = (int)($_POST['id'] ?? 0);
+    $existingImage = null;
+
+    if ($id) {
+        $existing = fetchOne('SELECT * FROM equipments WHERE id = :id', [':id' => $id]);
+        $existingImage = $existing['img'] ?? null;
+    }
+
+    try {
+        $image = handleImageUpload($_FILES['img'] ?? [], $existingImage);
+    } catch (RuntimeException $e) {
+        setFlash('error', $e->getMessage());
+        header('Location: equipments.php');
+        exit;
+    }
+
+    $params = [
+        ':title' => $title,
+        ':description' => $description,
+        ':more_info' => $moreInfo,
+        ':sort_order' => $sortOrder,
+    ];
+    if ($image) {
+        $params[':img'] = $image;
+    }
+
+    if ($id) {
+        $query = 'UPDATE equipments SET title = :title, description = :description, more_info = :more_info, sort_order = :sort_order';
+        if ($image) {
+            $query .= ', img = :img';
+        }
+        $query .= ' WHERE id = :id';
+        $params[':id'] = $id;
+    } else {
+        $query = 'INSERT INTO equipments (title, description, more_info, sort_order, img) VALUES (:title, :description, :more_info, :sort_order, :img)';
+        if (!$image) {
+            $params[':img'] = null;
+        }
+    }
+
+    executeQuery($query, $params);
+    setFlash('success', 'Ekipman kaydedildi.');
+    header('Location: equipments.php');
+    exit;
+}
+
+$equipments = fetchAll('SELECT * FROM equipments ORDER BY sort_order, id');
+$editId = isset($_GET['edit']) ? (int)$_GET['edit'] : 0;
+$editEquipment = $editId ? fetchOne('SELECT * FROM equipments WHERE id = :id', [':id' => $editId]) : null;
+$success = getFlash('success');
+$error = getFlash('error');
+?>
+<header>
+    <h1>Ekipmanlar</h1>
+</header>
+<?php if ($success): ?><div class="flash"><?= htmlspecialchars($success); ?></div><?php endif; ?>
+<?php if ($error): ?><div class="alert error"><?= htmlspecialchars($error); ?></div><?php endif; ?>
+<div class="card">
+    <h3><?= $editEquipment ? 'Ekipman Düzenle' : 'Yeni Ekipman'; ?></h3>
+    <form method="post" enctype="multipart/form-data">
+        <label for="title">Başlık</label>
+        <input type="text" name="title" id="title" value="<?= htmlspecialchars($editEquipment['title'] ?? ''); ?>" required>
+
+        <label for="description">Kısa Açıklama</label>
+        <textarea name="description" id="description" rows="4" required><?= htmlspecialchars($editEquipment['description'] ?? ''); ?></textarea>
+
+        <label for="more_info">Detaylı Bilgi</label>
+        <textarea name="more_info" id="more_info" rows="5"><?= htmlspecialchars($editEquipment['more_info'] ?? ''); ?></textarea>
+
+        <label for="sort_order">Sıra</label>
+        <input type="number" name="sort_order" id="sort_order" value="<?= htmlspecialchars($editEquipment['sort_order'] ?? 0); ?>">
+
+        <label for="img">Görsel</label>
+        <input type="file" name="img" id="img" accept="image/*">
+        <?php if (!empty($editEquipment['img'])): ?>
+            <p>Mevcut görsel: <strong><?= htmlspecialchars($editEquipment['img']); ?></strong></p>
+        <?php endif; ?>
+
+        <input type="hidden" name="id" value="<?= (int)($editEquipment['id'] ?? 0); ?>">
+        <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+        <button type="submit" class="btn primary">Kaydet</button>
+        <?php if ($editEquipment): ?>
+            <a class="btn secondary" href="equipments.php">İptal</a>
+        <?php endif; ?>
+    </form>
+</div>
+
+<div class="card">
+    <h3>Mevcut Ekipmanlar</h3>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Başlık</th>
+                <th>Sıra</th>
+                <th>İşlemler</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($equipments as $equipment): ?>
+                <tr>
+                    <td><?= htmlspecialchars($equipment['title']); ?></td>
+                    <td><?= (int)$equipment['sort_order']; ?></td>
+                    <td>
+                        <div class="table-actions">
+                            <a class="btn secondary" href="equipments.php?edit=<?= (int)$equipment['id']; ?>">Düzenle</a>
+                            <form method="post" onsubmit="return confirm('Ekipman silinsin mi?');">
+                                <input type="hidden" name="action" value="delete">
+                                <input type="hidden" name="id" value="<?= (int)$equipment['id']; ?>">
+                                <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+                                <button type="submit" class="btn danger">Sil</button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<?php
+require_once __DIR__ . '/layout-footer.php';

--- a/admin/faq.php
+++ b/admin/faq.php
@@ -1,0 +1,101 @@
+<?php
+require_once __DIR__ . '/header.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    validateCsrf($_POST['csrf_token'] ?? '');
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'delete') {
+        $id = (int)($_POST['id'] ?? 0);
+        executeQuery('DELETE FROM faq WHERE id = :id', [':id' => $id]);
+        setFlash('success', 'Soru silindi.');
+        header('Location: faq.php');
+        exit;
+    }
+
+    $question = trim($_POST['question'] ?? '');
+    $answer = trim($_POST['answer'] ?? '');
+    $sortOrder = (int)($_POST['sort_order'] ?? 0);
+    $id = (int)($_POST['id'] ?? 0);
+
+    $params = [
+        ':question' => $question,
+        ':answer' => $answer,
+        ':sort_order' => $sortOrder,
+    ];
+
+    if ($id) {
+        $params[':id'] = $id;
+        executeQuery('UPDATE faq SET question = :question, answer = :answer, sort_order = :sort_order WHERE id = :id', $params);
+    } else {
+        executeQuery('INSERT INTO faq (question, answer, sort_order) VALUES (:question, :answer, :sort_order)', $params);
+    }
+
+    setFlash('success', 'Soru kaydedildi.');
+    header('Location: faq.php');
+    exit;
+}
+
+$questions = fetchAll('SELECT * FROM faq ORDER BY sort_order, id');
+$editId = isset($_GET['edit']) ? (int)$_GET['edit'] : 0;
+$editQuestion = $editId ? fetchOne('SELECT * FROM faq WHERE id = :id', [':id' => $editId]) : null;
+$success = getFlash('success');
+?>
+<header>
+    <h1>Sık Sorulan Sorular</h1>
+</header>
+<?php if ($success): ?><div class="flash"><?= htmlspecialchars($success); ?></div><?php endif; ?>
+<div class="card">
+    <h3><?= $editQuestion ? 'Soruyu Düzenle' : 'Yeni Soru'; ?></h3>
+    <form method="post">
+        <label for="question">Soru</label>
+        <input type="text" name="question" id="question" value="<?= htmlspecialchars($editQuestion['question'] ?? ''); ?>" required>
+
+        <label for="answer">Cevap</label>
+        <textarea name="answer" id="answer" rows="4" required><?= htmlspecialchars($editQuestion['answer'] ?? ''); ?></textarea>
+
+        <label for="sort_order">Sıra</label>
+        <input type="number" name="sort_order" id="sort_order" value="<?= htmlspecialchars($editQuestion['sort_order'] ?? 0); ?>">
+
+        <input type="hidden" name="id" value="<?= (int)($editQuestion['id'] ?? 0); ?>">
+        <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+        <button type="submit" class="btn primary">Kaydet</button>
+        <?php if ($editQuestion): ?>
+            <a class="btn secondary" href="faq.php">İptal</a>
+        <?php endif; ?>
+    </form>
+</div>
+
+<div class="card">
+    <h3>Mevcut Sorular</h3>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Soru</th>
+                <th>Sıra</th>
+                <th>İşlemler</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($questions as $question): ?>
+                <tr>
+                    <td><?= htmlspecialchars($question['question']); ?></td>
+                    <td><?= (int)$question['sort_order']; ?></td>
+                    <td>
+                        <div class="table-actions">
+                            <a class="btn secondary" href="faq.php?edit=<?= (int)$question['id']; ?>">Düzenle</a>
+                            <form method="post" onsubmit="return confirm('Soru silinsin mi?');">
+                                <input type="hidden" name="action" value="delete">
+                                <input type="hidden" name="id" value="<?= (int)$question['id']; ?>">
+                                <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+                                <button type="submit" class="btn danger">Sil</button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<?php
+require_once __DIR__ . '/layout-footer.php';

--- a/admin/footer-links.php
+++ b/admin/footer-links.php
@@ -1,0 +1,111 @@
+<?php
+require_once __DIR__ . '/header.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    validateCsrf($_POST['csrf_token'] ?? '');
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'delete') {
+        $id = (int)($_POST['id'] ?? 0);
+        executeQuery('DELETE FROM footer_links WHERE id = :id', [':id' => $id]);
+        setFlash('success', 'Footer bağlantısı silindi.');
+        header('Location: footer-links.php');
+        exit;
+    }
+
+    $label = trim($_POST['label'] ?? '');
+    $url = trim($_POST['url'] ?? '');
+    $target = $_POST['target'] ?? '_self';
+    $position = (int)($_POST['position'] ?? 0);
+    $id = (int)($_POST['id'] ?? 0);
+
+    $params = [
+        ':label' => $label,
+        ':url' => $url,
+        ':target' => $target === '_blank' ? '_blank' : '_self',
+        ':position' => $position,
+    ];
+
+    if ($id) {
+        $params[':id'] = $id;
+        executeQuery('UPDATE footer_links SET label = :label, url = :url, target = :target, position = :position WHERE id = :id', $params);
+    } else {
+        executeQuery('INSERT INTO footer_links (label, url, target, position) VALUES (:label, :url, :target, :position)', $params);
+    }
+
+    setFlash('success', 'Footer bağlantısı kaydedildi.');
+    header('Location: footer-links.php');
+    exit;
+}
+
+$links = fetchAll('SELECT * FROM footer_links ORDER BY position ASC');
+$editId = isset($_GET['edit']) ? (int)$_GET['edit'] : 0;
+$editLink = $editId ? fetchOne('SELECT * FROM footer_links WHERE id = :id', [':id' => $editId]) : null;
+$success = getFlash('success');
+?>
+<header>
+    <h1>Footer Bağlantıları</h1>
+</header>
+<?php if ($success): ?><div class="flash"><?= htmlspecialchars($success); ?></div><?php endif; ?>
+<div class="card">
+    <h3><?= $editLink ? 'Bağlantıyı Düzenle' : 'Yeni Bağlantı'; ?></h3>
+    <form method="post">
+        <label for="label">Başlık</label>
+        <input type="text" name="label" id="label" value="<?= htmlspecialchars($editLink['label'] ?? ''); ?>" required>
+
+        <label for="url">URL</label>
+        <input type="url" name="url" id="url" value="<?= htmlspecialchars($editLink['url'] ?? ''); ?>" required>
+
+        <label for="target">Hedef</label>
+        <select name="target" id="target">
+            <option value="_self" <?= ($editLink['target'] ?? '_self') === '_self' ? 'selected' : ''; ?>>Aynı sayfa</option>
+            <option value="_blank" <?= ($editLink['target'] ?? '_self') === '_blank' ? 'selected' : ''; ?>>Yeni sekme</option>
+        </select>
+
+        <label for="position">Sıra</label>
+        <input type="number" name="position" id="position" value="<?= htmlspecialchars($editLink['position'] ?? 0); ?>">
+
+        <input type="hidden" name="id" value="<?= (int)($editLink['id'] ?? 0); ?>">
+        <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+        <button type="submit" class="btn primary">Kaydet</button>
+        <?php if ($editLink): ?>
+            <a class="btn secondary" href="footer-links.php">İptal</a>
+        <?php endif; ?>
+    </form>
+</div>
+
+<div class="card">
+    <h3>Mevcut Bağlantılar</h3>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Başlık</th>
+                <th>URL</th>
+                <th>Sıra</th>
+                <th>İşlemler</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($links as $link): ?>
+                <tr>
+                    <td><?= htmlspecialchars($link['label']); ?></td>
+                    <td><?= htmlspecialchars($link['url']); ?></td>
+                    <td><?= (int)$link['position']; ?></td>
+                    <td>
+                        <div class="table-actions">
+                            <a class="btn secondary" href="footer-links.php?edit=<?= (int)$link['id']; ?>">Düzenle</a>
+                            <form method="post" onsubmit="return confirm('Bağlantı silinsin mi?');">
+                                <input type="hidden" name="action" value="delete">
+                                <input type="hidden" name="id" value="<?= (int)$link['id']; ?>">
+                                <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+                                <button type="submit" class="btn danger">Sil</button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<?php
+require_once __DIR__ . '/layout-footer.php';

--- a/admin/header.php
+++ b/admin/header.php
@@ -1,0 +1,51 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+requireLogin();
+
+$section = basename($_SERVER['PHP_SELF']);
+$menu = [
+    'index.php' => 'Genel Bakış',
+    'settings.php' => 'Site Ayarları',
+    'hero.php' => 'Hero',
+    'content.php' => 'Metinler',
+    'equipments.php' => 'Ekipmanlar',
+    'trainings.php' => 'Eğitimler',
+    'plans.php' => 'Planlar',
+    'schedule.php' => 'Ders Programı',
+    'faq.php' => 'S.S.S.',
+    'messages.php' => 'Mesajlar',
+    'footer-links.php' => 'Footer',
+];
+
+$siteName = setting('site_name', 'Pi Studio Pilates');
+$adminLang = setting('language', 'tr');
+?>
+<!DOCTYPE html>
+<html lang="<?= htmlspecialchars($adminLang); ?>">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= htmlspecialchars($siteName); ?> | Admin</title>
+    <link rel="stylesheet" href="../assets/css/admin.css">
+</head>
+<body>
+<div class="admin-layout">
+    <aside class="sidebar">
+        <div>
+            <h2><?= htmlspecialchars($siteName); ?></h2>
+            <nav>
+                <ul>
+                    <?php foreach ($menu as $file => $label): ?>
+                        <li><a href="<?= $file; ?>" class="<?= $file === $section ? 'active' : ''; ?>"><?= htmlspecialchars($label); ?></a></li>
+                    <?php endforeach; ?>
+                </ul>
+            </nav>
+        </div>
+        <div>
+            <span class="badge"><?= htmlspecialchars($_SESSION['user_email'] ?? ''); ?></span>
+            <div style="margin-top:1rem;">
+                <a class="btn secondary" href="logout.php">Çıkış</a>
+            </div>
+        </div>
+    </aside>
+    <main class="admin-content">

--- a/admin/hero.php
+++ b/admin/hero.php
@@ -1,0 +1,97 @@
+<?php
+require_once __DIR__ . '/header.php';
+
+$hero = fetchOne('SELECT * FROM hero LIMIT 1');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    validateCsrf($_POST['csrf_token'] ?? '');
+
+    $data = [
+        ':title' => trim($_POST['title'] ?? ''),
+        ':subtitle' => trim($_POST['subtitle'] ?? ''),
+        ':cta_primary_text' => trim($_POST['cta_primary_text'] ?? ''),
+        ':cta_secondary_text' => trim($_POST['cta_secondary_text'] ?? ''),
+        ':cta_primary_link' => trim($_POST['cta_primary_link'] ?? ''),
+        ':cta_secondary_link' => trim($_POST['cta_secondary_link'] ?? ''),
+        ':address' => trim($_POST['address'] ?? ''),
+        ':map_embed' => trim($_POST['map_embed'] ?? ''),
+    ];
+
+    try {
+        $image = handleImageUpload($_FILES['background_media'] ?? [], $hero['background_media'] ?? null);
+    } catch (RuntimeException $e) {
+        setFlash('error', $e->getMessage());
+        header('Location: hero.php');
+        exit;
+    }
+
+    if ($image) {
+        $data[':background_media'] = $image;
+    }
+
+    if ($hero) {
+        $query = 'UPDATE hero SET title = :title, subtitle = :subtitle, cta_primary_text = :cta_primary_text, cta_secondary_text = :cta_secondary_text, cta_primary_link = :cta_primary_link, cta_secondary_link = :cta_secondary_link, address = :address, map_embed = :map_embed';
+        if ($image) {
+            $query .= ', background_media = :background_media';
+        }
+        $query .= ' WHERE id = :id';
+        $data[':id'] = $hero['id'];
+    } else {
+        $query = 'INSERT INTO hero (title, subtitle, cta_primary_text, cta_secondary_text, cta_primary_link, cta_secondary_link, address, map_embed, background_media) VALUES (:title, :subtitle, :cta_primary_text, :cta_secondary_text, :cta_primary_link, :cta_secondary_link, :address, :map_embed, :background_media)';
+        if (!$image) {
+            $data[':background_media'] = null;
+        }
+    }
+
+    executeQuery($query, $data);
+    setFlash('success', 'Hero alanı güncellendi.');
+    header('Location: hero.php');
+    exit;
+}
+
+$success = getFlash('success');
+$error = getFlash('error');
+?>
+<header>
+    <h1>Hero Bölümü</h1>
+</header>
+<?php if ($success): ?><div class="flash"><?= htmlspecialchars($success); ?></div><?php endif; ?>
+<?php if ($error): ?><div class="alert error"><?= htmlspecialchars($error); ?></div><?php endif; ?>
+<div class="card">
+    <form method="post" enctype="multipart/form-data">
+        <label for="title">Başlık</label>
+        <input type="text" name="title" id="title" value="<?= htmlspecialchars($hero['title'] ?? ''); ?>" required>
+
+        <label for="subtitle">Alt Başlık</label>
+        <textarea name="subtitle" id="subtitle" rows="3"><?= htmlspecialchars($hero['subtitle'] ?? ''); ?></textarea>
+
+        <label for="cta_primary_text">Birincil Buton Metni</label>
+        <input type="text" name="cta_primary_text" id="cta_primary_text" value="<?= htmlspecialchars($hero['cta_primary_text'] ?? ''); ?>">
+
+        <label for="cta_primary_link">Birincil Buton Linki</label>
+        <input type="text" name="cta_primary_link" id="cta_primary_link" value="<?= htmlspecialchars($hero['cta_primary_link'] ?? ''); ?>">
+
+        <label for="cta_secondary_text">İkincil Buton Metni</label>
+        <input type="text" name="cta_secondary_text" id="cta_secondary_text" value="<?= htmlspecialchars($hero['cta_secondary_text'] ?? ''); ?>">
+
+        <label for="cta_secondary_link">İkincil Buton Linki</label>
+        <input type="text" name="cta_secondary_link" id="cta_secondary_link" value="<?= htmlspecialchars($hero['cta_secondary_link'] ?? ''); ?>">
+
+        <label for="address">Adres</label>
+        <textarea name="address" id="address" rows="2"><?= htmlspecialchars($hero['address'] ?? ''); ?></textarea>
+
+        <label for="map_embed">Google Maps Embed (iframe kodu veya sadece src)</label>
+        <textarea name="map_embed" id="map_embed" rows="4"><?= htmlspecialchars($hero['map_embed'] ?? ''); ?></textarea>
+
+        <label for="background_media">Arka Plan Görseli</label>
+        <input type="file" name="background_media" id="background_media" accept="image/*">
+        <?php if (!empty($hero['background_media'])): ?>
+            <p>Mevcut görsel: <strong><?= htmlspecialchars($hero['background_media']); ?></strong></p>
+        <?php endif; ?>
+
+        <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+        <button type="submit" class="btn primary">Kaydet</button>
+    </form>
+</div>
+<?php
+require_once __DIR__ . '/layout-footer.php';

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/header.php';
+
+$counts = [
+    'equipments' => fetchOne('SELECT COUNT(*) AS total FROM equipments')['total'] ?? 0,
+    'trainings' => fetchOne('SELECT COUNT(*) AS total FROM trainings')['total'] ?? 0,
+    'plans' => fetchOne('SELECT COUNT(*) AS total FROM plans')['total'] ?? 0,
+    'faq' => fetchOne('SELECT COUNT(*) AS total FROM faq')['total'] ?? 0,
+    'messages' => fetchOne('SELECT COUNT(*) AS total FROM messages')['total'] ?? 0,
+];
+?>
+<header>
+    <h1>Kontrol Paneli</h1>
+</header>
+<div class="card">
+    <h3>Özet</h3>
+    <ul>
+        <li>Ekipmanlar: <?= (int)$counts['equipments']; ?></li>
+        <li>Eğitimler: <?= (int)$counts['trainings']; ?></li>
+        <li>Planlar: <?= (int)$counts['plans']; ?></li>
+        <li>S.S.S.: <?= (int)$counts['faq']; ?></li>
+        <li>Mesajlar: <?= (int)$counts['messages']; ?></li>
+    </ul>
+</div>
+<?php
+require_once __DIR__ . '/layout-footer.php';

--- a/admin/layout-footer.php
+++ b/admin/layout-footer.php
@@ -1,0 +1,4 @@
+    </main>
+</div>
+</body>
+</html>

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,50 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+
+if (isLoggedIn()) {
+    header('Location: index.php');
+    exit;
+}
+
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    validateCsrf($_POST['csrf_token'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+
+    $user = fetchOne('SELECT * FROM users WHERE email = :email', [':email' => $email]);
+
+    if ($user && password_verify($password, $user['password'])) {
+        $_SESSION['user_id'] = $user['id'];
+        $_SESSION['user_email'] = $user['email'];
+        header('Location: index.php');
+        exit;
+    }
+
+    $error = 'Geçersiz giriş bilgileri.';
+}
+
+?><!DOCTYPE html>
+<html lang="<?= htmlspecialchars(setting('language', 'tr')); ?>">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= htmlspecialchars(setting('site_name', 'Pi Studio Pilates')); ?> | Admin Giriş</title>
+    <link rel="stylesheet" href="../assets/css/admin.css">
+</head>
+<body class="auth">
+    <form class="auth-card" method="post">
+        <h1>Admin Giriş</h1>
+        <?php if ($error): ?>
+            <div class="alert error"><?= htmlspecialchars($error); ?></div>
+        <?php endif; ?>
+        <label for="email">E-posta</label>
+        <input type="email" name="email" id="email" required>
+        <label for="password">Şifre</label>
+        <input type="password" name="password" id="password" required>
+        <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+        <button type="submit" class="btn primary">Giriş Yap</button>
+    </form>
+</body>
+</html>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -1,0 +1,7 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+
+$_SESSION = [];
+session_destroy();
+header('Location: login.php');
+exit;

--- a/admin/messages.php
+++ b/admin/messages.php
@@ -1,0 +1,36 @@
+<?php
+require_once __DIR__ . '/header.php';
+
+$messages = fetchAll('SELECT * FROM messages ORDER BY created_at DESC');
+?>
+<header>
+    <h1>İletişim Mesajları</h1>
+</header>
+<div class="card">
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Ad Soyad</th>
+                <th>E-posta</th>
+                <th>Telefon</th>
+                <th>Tercih</th>
+                <th>Mesaj</th>
+                <th>Tarih</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($messages as $message): ?>
+                <tr>
+                    <td><?= htmlspecialchars($message['name']); ?></td>
+                    <td><a href="mailto:<?= htmlspecialchars($message['email']); ?>"><?= htmlspecialchars($message['email']); ?></a></td>
+                    <td><?= htmlspecialchars($message['phone']); ?></td>
+                    <td><?= htmlspecialchars($message['preference']); ?></td>
+                    <td><?= nl2br(htmlspecialchars($message['message'])); ?></td>
+                    <td><?= htmlspecialchars($message['created_at']); ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<?php
+require_once __DIR__ . '/layout-footer.php';

--- a/admin/plans.php
+++ b/admin/plans.php
@@ -1,0 +1,108 @@
+<?php
+require_once __DIR__ . '/header.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    validateCsrf($_POST['csrf_token'] ?? '');
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'delete') {
+        $id = (int)($_POST['id'] ?? 0);
+        executeQuery('DELETE FROM plans WHERE id = :id', [':id' => $id]);
+        setFlash('success', 'Plan silindi.');
+        header('Location: plans.php');
+        exit;
+    }
+
+    $title = trim($_POST['title'] ?? '');
+    $price = trim($_POST['price'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $sortOrder = (int)($_POST['sort_order'] ?? 0);
+    $id = (int)($_POST['id'] ?? 0);
+
+    $params = [
+        ':title' => $title,
+        ':price' => $price,
+        ':description' => $description,
+        ':sort_order' => $sortOrder,
+    ];
+
+    if ($id) {
+        $params[':id'] = $id;
+        executeQuery('UPDATE plans SET title = :title, price = :price, description = :description, sort_order = :sort_order WHERE id = :id', $params);
+    } else {
+        executeQuery('INSERT INTO plans (title, price, description, sort_order) VALUES (:title, :price, :description, :sort_order)', $params);
+    }
+
+    setFlash('success', 'Plan kaydedildi.');
+    header('Location: plans.php');
+    exit;
+}
+
+$plans = fetchAll('SELECT * FROM plans ORDER BY sort_order, id');
+$editId = isset($_GET['edit']) ? (int)$_GET['edit'] : 0;
+$editPlan = $editId ? fetchOne('SELECT * FROM plans WHERE id = :id', [':id' => $editId]) : null;
+$success = getFlash('success');
+?>
+<header>
+    <h1>Ders Planları</h1>
+</header>
+<?php if ($success): ?><div class="flash"><?= htmlspecialchars($success); ?></div><?php endif; ?>
+<div class="card">
+    <h3><?= $editPlan ? 'Planı Düzenle' : 'Yeni Plan'; ?></h3>
+    <form method="post">
+        <label for="title">Plan Adı</label>
+        <input type="text" name="title" id="title" value="<?= htmlspecialchars($editPlan['title'] ?? ''); ?>" required>
+
+        <label for="price">Fiyat</label>
+        <input type="text" name="price" id="price" value="<?= htmlspecialchars($editPlan['price'] ?? ''); ?>" required>
+
+        <label for="description">Açıklama</label>
+        <textarea name="description" id="description" rows="4" required><?= htmlspecialchars($editPlan['description'] ?? ''); ?></textarea>
+
+        <label for="sort_order">Sıra</label>
+        <input type="number" name="sort_order" id="sort_order" value="<?= htmlspecialchars($editPlan['sort_order'] ?? 0); ?>">
+
+        <input type="hidden" name="id" value="<?= (int)($editPlan['id'] ?? 0); ?>">
+        <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+        <button type="submit" class="btn primary">Kaydet</button>
+        <?php if ($editPlan): ?>
+            <a class="btn secondary" href="plans.php">İptal</a>
+        <?php endif; ?>
+    </form>
+</div>
+
+<div class="card">
+    <h3>Mevcut Planlar</h3>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Plan</th>
+                <th>Fiyat</th>
+                <th>Sıra</th>
+                <th>İşlemler</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($plans as $plan): ?>
+                <tr>
+                    <td><?= htmlspecialchars($plan['title']); ?></td>
+                    <td><?= htmlspecialchars($plan['price']); ?></td>
+                    <td><?= (int)$plan['sort_order']; ?></td>
+                    <td>
+                        <div class="table-actions">
+                            <a class="btn secondary" href="plans.php?edit=<?= (int)$plan['id']; ?>">Düzenle</a>
+                            <form method="post" onsubmit="return confirm('Plan silinsin mi?');">
+                                <input type="hidden" name="action" value="delete">
+                                <input type="hidden" name="id" value="<?= (int)$plan['id']; ?>">
+                                <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+                                <button type="submit" class="btn danger">Sil</button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<?php
+require_once __DIR__ . '/layout-footer.php';

--- a/admin/schedule.php
+++ b/admin/schedule.php
@@ -1,0 +1,124 @@
+<?php
+require_once __DIR__ . '/header.php';
+
+$days = [
+    1 => 'Pazartesi',
+    2 => 'Salı',
+    3 => 'Çarşamba',
+    4 => 'Perşembe',
+    5 => 'Cuma',
+    6 => 'Cumartesi',
+    7 => 'Pazar',
+];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    validateCsrf($_POST['csrf_token'] ?? '');
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'delete') {
+        $id = (int)($_POST['id'] ?? 0);
+        executeQuery('DELETE FROM schedule_entries WHERE id = :id', [':id' => $id]);
+        setFlash('success', 'Ders programı satırı silindi.');
+        header('Location: schedule.php');
+        exit;
+    }
+
+    $dayOrder = (int)($_POST['day_order'] ?? 1);
+    $startTime = $_POST['start_time'] ?? '09:00';
+    $classType = trim($_POST['class_type'] ?? '');
+    $level = trim($_POST['level'] ?? '');
+    $id = (int)($_POST['id'] ?? 0);
+
+    $params = [
+        ':day_order' => $dayOrder,
+        ':start_time' => $startTime,
+        ':class_type' => $classType,
+        ':level' => $level,
+    ];
+
+    if ($id) {
+        $params[':id'] = $id;
+        executeQuery('UPDATE schedule_entries SET day_order = :day_order, start_time = :start_time, class_type = :class_type, level = :level WHERE id = :id', $params);
+    } else {
+        executeQuery('INSERT INTO schedule_entries (day_order, start_time, class_type, level) VALUES (:day_order, :start_time, :class_type, :level)', $params);
+    }
+
+    setFlash('success', 'Ders programı kaydedildi.');
+    header('Location: schedule.php');
+    exit;
+}
+
+$schedule = fetchAll('SELECT * FROM schedule_entries ORDER BY day_order, start_time');
+$editId = isset($_GET['edit']) ? (int)$_GET['edit'] : 0;
+$editEntry = $editId ? fetchOne('SELECT * FROM schedule_entries WHERE id = :id', [':id' => $editId]) : null;
+$success = getFlash('success');
+?>
+<header>
+    <h1>Ders Programı</h1>
+</header>
+<?php if ($success): ?><div class="flash"><?= htmlspecialchars($success); ?></div><?php endif; ?>
+<div class="card">
+    <h3><?= $editEntry ? 'Program Satırı Düzenle' : 'Yeni Program Satırı'; ?></h3>
+    <form method="post">
+        <label for="day_order">Gün</label>
+        <select name="day_order" id="day_order">
+            <?php foreach ($days as $value => $label): ?>
+                <option value="<?= $value; ?>" <?= (int)($editEntry['day_order'] ?? 1) === $value ? 'selected' : ''; ?>><?= htmlspecialchars($label); ?></option>
+            <?php endforeach; ?>
+        </select>
+
+        <label for="start_time">Saat</label>
+        <input type="time" name="start_time" id="start_time" value="<?= htmlspecialchars($editEntry['start_time'] ?? '09:00'); ?>">
+
+        <label for="class_type">Ders</label>
+        <input type="text" name="class_type" id="class_type" value="<?= htmlspecialchars($editEntry['class_type'] ?? ''); ?>" required>
+
+        <label for="level">Seviye</label>
+        <input type="text" name="level" id="level" value="<?= htmlspecialchars($editEntry['level'] ?? ''); ?>">
+
+        <input type="hidden" name="id" value="<?= (int)($editEntry['id'] ?? 0); ?>">
+        <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+        <button type="submit" class="btn primary">Kaydet</button>
+        <?php if ($editEntry): ?>
+            <a class="btn secondary" href="schedule.php">İptal</a>
+        <?php endif; ?>
+    </form>
+</div>
+
+<div class="card">
+    <h3>Mevcut Program</h3>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Gün</th>
+                <th>Saat</th>
+                <th>Ders</th>
+                <th>Seviye</th>
+                <th>İşlemler</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($schedule as $entry): ?>
+                <tr>
+                    <td><?= htmlspecialchars($days[(int)$entry['day_order']]); ?></td>
+                    <td><?= htmlspecialchars(substr($entry['start_time'], 0, 5)); ?></td>
+                    <td><?= htmlspecialchars($entry['class_type']); ?></td>
+                    <td><?= htmlspecialchars($entry['level']); ?></td>
+                    <td>
+                        <div class="table-actions">
+                            <a class="btn secondary" href="schedule.php?edit=<?= (int)$entry['id']; ?>">Düzenle</a>
+                            <form method="post" onsubmit="return confirm('Satır silinsin mi?');">
+                                <input type="hidden" name="action" value="delete">
+                                <input type="hidden" name="id" value="<?= (int)$entry['id']; ?>">
+                                <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+                                <button type="submit" class="btn danger">Sil</button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<?php
+require_once __DIR__ . '/layout-footer.php';

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -1,0 +1,110 @@
+<?php
+require_once __DIR__ . '/header.php';
+
+$settings = get_settings();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    validateCsrf($_POST['csrf_token'] ?? '');
+
+    $siteName = trim($_POST['site_name'] ?? '');
+    $language = trim($_POST['language'] ?? 'tr');
+    $contactEmail = trim($_POST['contact_email'] ?? '');
+    $contactPhone = trim($_POST['contact_phone'] ?? '');
+    $whatsappNumber = trim($_POST['whatsapp_number'] ?? '');
+    $instagramUrl = trim($_POST['instagram_url'] ?? '');
+    $address = trim($_POST['address'] ?? '');
+
+    if ($siteName === '') {
+        setFlash('error', 'Site adı boş bırakılamaz.');
+        header('Location: settings.php');
+        exit;
+    }
+
+    try {
+        $logo = handleImageUpload($_FILES['logo'] ?? [], $settings['logo'] ?? null);
+    } catch (RuntimeException $e) {
+        setFlash('error', $e->getMessage());
+        header('Location: settings.php');
+        exit;
+    }
+
+    $payload = [
+        ':site_name' => $siteName,
+        ':language' => $language ?: 'tr',
+        ':contact_email' => $contactEmail,
+        ':contact_phone' => $contactPhone,
+        ':whatsapp_number' => $whatsappNumber,
+        ':instagram_url' => $instagramUrl,
+        ':address' => $address,
+    ];
+
+    if ($logo) {
+        $payload[':logo'] = $logo;
+    }
+
+    if ($settings) {
+        $query = 'UPDATE settings SET site_name = :site_name, language = :language, contact_email = :contact_email, contact_phone = :contact_phone, whatsapp_number = :whatsapp_number, instagram_url = :instagram_url, address = :address';
+        if ($logo) {
+            $query .= ', logo = :logo';
+        }
+        $query .= ' WHERE id = :id';
+        $payload[':id'] = $settings['id'];
+    } else {
+        $query = 'INSERT INTO settings (site_name, language, contact_email, contact_phone, whatsapp_number, instagram_url, address, logo) VALUES (:site_name, :language, :contact_email, :contact_phone, :whatsapp_number, :instagram_url, :address, :logo)';
+        if (!$logo) {
+            $payload[':logo'] = null;
+        }
+    }
+
+    executeQuery($query, $payload);
+    refresh_settings();
+
+    setFlash('success', 'Genel ayarlar kaydedildi.');
+    header('Location: settings.php');
+    exit;
+}
+
+$success = getFlash('success');
+$error = getFlash('error');
+$settings = get_settings();
+?>
+<header>
+    <h1>Site Ayarları</h1>
+</header>
+<?php if ($success): ?><div class="flash"><?= htmlspecialchars($success); ?></div><?php endif; ?>
+<?php if ($error): ?><div class="alert error"><?= htmlspecialchars($error); ?></div><?php endif; ?>
+<div class="card">
+    <form method="post" enctype="multipart/form-data">
+        <label for="site_name">Site Adı</label>
+        <input type="text" id="site_name" name="site_name" value="<?= htmlspecialchars($settings['site_name'] ?? 'Pi Studio Pilates'); ?>" required>
+
+        <label for="language">Dil Kodu (ör. tr, en)</label>
+        <input type="text" id="language" name="language" value="<?= htmlspecialchars($settings['language'] ?? 'tr'); ?>" maxlength="5">
+
+        <label for="contact_email">İletişim E-postası</label>
+        <input type="email" id="contact_email" name="contact_email" value="<?= htmlspecialchars($settings['contact_email'] ?? 'info@pistudiopilates.com'); ?>">
+
+        <label for="contact_phone">İletişim Telefonu</label>
+        <input type="text" id="contact_phone" name="contact_phone" value="<?= htmlspecialchars($settings['contact_phone'] ?? '+90 530 111 22 33'); ?>">
+
+        <label for="whatsapp_number">WhatsApp Numarası</label>
+        <input type="text" id="whatsapp_number" name="whatsapp_number" value="<?= htmlspecialchars($settings['whatsapp_number'] ?? '+90 530 111 22 33'); ?>">
+
+        <label for="instagram_url">Instagram URL</label>
+        <input type="url" id="instagram_url" name="instagram_url" value="<?= htmlspecialchars($settings['instagram_url'] ?? 'https://www.instagram.com'); ?>">
+
+        <label for="address">Adres</label>
+        <textarea id="address" name="address" rows="3"><?= htmlspecialchars($settings['address'] ?? 'Bağdat Caddesi No:123, İstanbul'); ?></textarea>
+
+        <label for="logo">Logo</label>
+        <input type="file" id="logo" name="logo" accept="image/*">
+        <?php if (!empty($settings['logo'])): ?>
+            <p>Mevcut logo: <strong><?= htmlspecialchars($settings['logo']); ?></strong></p>
+        <?php endif; ?>
+
+        <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+        <button type="submit" class="btn primary">Kaydet</button>
+    </form>
+</div>
+<?php
+require_once __DIR__ . '/layout-footer.php';

--- a/admin/trainings.php
+++ b/admin/trainings.php
@@ -1,0 +1,147 @@
+<?php
+require_once __DIR__ . '/header.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    validateCsrf($_POST['csrf_token'] ?? '');
+    $action = $_POST['action'] ?? '';
+
+    if ($action === 'delete') {
+        $id = (int)($_POST['id'] ?? 0);
+        $training = fetchOne('SELECT * FROM trainings WHERE id = :id', [':id' => $id]);
+        if ($training) {
+            if (!empty($training['img']) && file_exists(UPLOAD_DIR . $training['img'])) {
+                @unlink(UPLOAD_DIR . $training['img']);
+            }
+            executeQuery('DELETE FROM trainings WHERE id = :id', [':id' => $id]);
+            setFlash('success', 'Eğitim silindi.');
+        }
+        header('Location: trainings.php');
+        exit;
+    }
+
+    $title = trim($_POST['title'] ?? '');
+    $year = trim($_POST['year'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $sortOrder = (int)($_POST['sort_order'] ?? 0);
+    $id = (int)($_POST['id'] ?? 0);
+    $existingImage = null;
+
+    if ($id) {
+        $existing = fetchOne('SELECT * FROM trainings WHERE id = :id', [':id' => $id]);
+        $existingImage = $existing['img'] ?? null;
+    }
+
+    try {
+        $image = handleImageUpload($_FILES['img'] ?? [], $existingImage);
+    } catch (RuntimeException $e) {
+        setFlash('error', $e->getMessage());
+        header('Location: trainings.php');
+        exit;
+    }
+
+    $params = [
+        ':title' => $title,
+        ':year' => $year,
+        ':description' => $description,
+        ':sort_order' => $sortOrder,
+    ];
+    if ($image) {
+        $params[':img'] = $image;
+    }
+
+    if ($id) {
+        $query = 'UPDATE trainings SET title = :title, year = :year, description = :description, sort_order = :sort_order';
+        if ($image) {
+            $query .= ', img = :img';
+        }
+        $query .= ' WHERE id = :id';
+        $params[':id'] = $id;
+    } else {
+        $query = 'INSERT INTO trainings (title, year, description, sort_order, img) VALUES (:title, :year, :description, :sort_order, :img)';
+        if (!$image) {
+            $params[':img'] = null;
+        }
+    }
+
+    executeQuery($query, $params);
+    setFlash('success', 'Eğitim kaydedildi.');
+    header('Location: trainings.php');
+    exit;
+}
+
+$trainings = fetchAll('SELECT * FROM trainings ORDER BY sort_order, id');
+$editId = isset($_GET['edit']) ? (int)$_GET['edit'] : 0;
+$editTraining = $editId ? fetchOne('SELECT * FROM trainings WHERE id = :id', [':id' => $editId]) : null;
+$success = getFlash('success');
+$error = getFlash('error');
+?>
+<header>
+    <h1>Eğitimler</h1>
+</header>
+<?php if ($success): ?><div class="flash"><?= htmlspecialchars($success); ?></div><?php endif; ?>
+<?php if ($error): ?><div class="alert error"><?= htmlspecialchars($error); ?></div><?php endif; ?>
+<div class="card">
+    <h3><?= $editTraining ? 'Eğitim Düzenle' : 'Yeni Eğitim'; ?></h3>
+    <form method="post" enctype="multipart/form-data">
+        <label for="title">Başlık</label>
+        <input type="text" name="title" id="title" value="<?= htmlspecialchars($editTraining['title'] ?? ''); ?>" required>
+
+        <label for="year">Yıl / Durum</label>
+        <input type="text" name="year" id="year" value="<?= htmlspecialchars($editTraining['year'] ?? ''); ?>">
+
+        <label for="description">Açıklama</label>
+        <textarea name="description" id="description" rows="5" required><?= htmlspecialchars($editTraining['description'] ?? ''); ?></textarea>
+
+        <label for="sort_order">Sıra</label>
+        <input type="number" name="sort_order" id="sort_order" value="<?= htmlspecialchars($editTraining['sort_order'] ?? 0); ?>">
+
+        <label for="img">Görsel</label>
+        <input type="file" name="img" id="img" accept="image/*">
+        <?php if (!empty($editTraining['img'])): ?>
+            <p>Mevcut görsel: <strong><?= htmlspecialchars($editTraining['img']); ?></strong></p>
+        <?php endif; ?>
+
+        <input type="hidden" name="id" value="<?= (int)($editTraining['id'] ?? 0); ?>">
+        <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+        <button type="submit" class="btn primary">Kaydet</button>
+        <?php if ($editTraining): ?>
+            <a class="btn secondary" href="trainings.php">İptal</a>
+        <?php endif; ?>
+    </form>
+</div>
+
+<div class="card">
+    <h3>Mevcut Eğitimler</h3>
+    <table class="table">
+        <thead>
+            <tr>
+                <th>Başlık</th>
+                <th>Yıl</th>
+                <th>Sıra</th>
+                <th>İşlemler</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($trainings as $training): ?>
+                <tr>
+                    <td><?= htmlspecialchars($training['title']); ?></td>
+                    <td><?= htmlspecialchars($training['year']); ?></td>
+                    <td><?= (int)$training['sort_order']; ?></td>
+                    <td>
+                        <div class="table-actions">
+                            <a class="btn secondary" href="trainings.php?edit=<?= (int)$training['id']; ?>">Düzenle</a>
+                            <form method="post" onsubmit="return confirm('Eğitim silinsin mi?');">
+                                <input type="hidden" name="action" value="delete">
+                                <input type="hidden" name="id" value="<?= (int)$training['id']; ?>">
+                                <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+                                <button type="submit" class="btn danger">Sil</button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>
+<?php
+require_once __DIR__ . '/layout-footer.php';

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,0 +1,234 @@
+:root {
+  --primary: #7c4dff;
+  --danger: #ff5252;
+  --bg: #f5f7fb;
+  --text: #1f2937;
+  --font-sans: 'Inter', 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+}
+
+body.auth {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.auth-card {
+  background: #fff;
+  padding: 2.5rem;
+  border-radius: 1.25rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
+  width: min(420px, 100%);
+  display: grid;
+  gap: 1rem;
+}
+
+.auth-card h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.75rem;
+}
+
+.auth-card label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.auth-card input {
+  padding: 0.8rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  font-size: 1rem;
+}
+
+.btn.primary {
+  background: var(--primary);
+  color: #fff;
+  padding: 0.9rem 1.2rem;
+  border-radius: 0.9rem;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn {
+  display: inline-block;
+}
+
+.alert {
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+}
+
+.alert.error {
+  background: rgba(255, 82, 82, 0.15);
+  color: #b71c1c;
+}
+
+a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.admin-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: #fff;
+  padding: 2rem 1.5rem;
+  border-right: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.sidebar h2 {
+  margin: 0 0 1.5rem;
+}
+
+.sidebar nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.sidebar nav a {
+  display: block;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.sidebar nav a.active,
+.sidebar nav a:hover {
+  background: rgba(124, 77, 255, 0.12);
+}
+
+.admin-content {
+  padding: 2.5rem;
+}
+
+.admin-content header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.08);
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.card form {
+  display: grid;
+  gap: 1rem;
+}
+
+.card label {
+  font-weight: 600;
+}
+
+.card input,
+.card textarea,
+.card select {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  text-align: left;
+}
+
+.table-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.table-actions form {
+  display: inline;
+}
+
+.btn.secondary {
+  background: rgba(124, 77, 255, 0.15);
+  color: var(--primary);
+  border: none;
+  padding: 0.7rem 1.1rem;
+  border-radius: 0.75rem;
+  cursor: pointer;
+}
+
+.btn.danger {
+  background: rgba(255, 82, 82, 0.15);
+  color: #c62828;
+  border: none;
+  padding: 0.7rem 1.1rem;
+  border-radius: 0.75rem;
+  cursor: pointer;
+}
+
+.badge {
+  display: inline-block;
+  background: rgba(124, 77, 255, 0.12);
+  color: var(--primary);
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+}
+
+.flash {
+  background: rgba(0, 191, 165, 0.15);
+  color: #00695c;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+@media (max-width: 960px) {
+  .admin-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    border-right: none;
+    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .sidebar nav ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,508 @@
+:root {
+  --pi-primary: #2563eb;
+  --pi-primary-dark: #1d4ed8;
+  --pi-secondary: #f97316;
+  --pi-dark: #0f172a;
+  --pi-text: #1f2937;
+  --pi-light: #f8fafc;
+  --pi-muted: #6b7280;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Poppins', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  background-color: #ffffff;
+  color: var(--pi-text);
+  line-height: 1.6;
+  padding-top: 76px;
+}
+
+@media (min-width: 992px) {
+  body {
+    padding-top: 88px;
+  }
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--pi-primary-dark);
+}
+
+.navbar {
+  transition: background-color 0.3s ease, box-shadow 0.3s ease, padding 0.3s ease;
+  background-color: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(12px);
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.navbar .navbar-brand {
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.navbar .navbar-brand img {
+  height: 48px;
+  width: auto;
+}
+
+.navbar .nav-link {
+  font-weight: 500;
+  color: var(--pi-text);
+  margin: 0 0.75rem;
+  position: relative;
+  padding: 0.5rem 0;
+}
+
+.navbar .nav-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--pi-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
+}
+
+.navbar .nav-link:focus::after,
+.navbar .nav-link:hover::after {
+  transform: scaleX(1);
+}
+
+.navbar-scrolled {
+  background-color: #ffffff;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  padding-top: 0.5rem !important;
+  padding-bottom: 0.5rem !important;
+}
+
+.hero {
+  position: relative;
+  min-height: calc(100vh - 76px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background-image: var(--hero-image);
+  background-size: cover;
+  background-position: center;
+  color: #ffffff;
+  overflow: hidden;
+}
+
+@media (min-width: 992px) {
+  .hero {
+    min-height: calc(100vh - 88px);
+  }
+}
+
+.hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.68);
+}
+
+.hero .container {
+  position: relative;
+  z-index: 1;
+  padding: 6rem 1rem;
+}
+
+.hero-kicker {
+  display: inline-block;
+  font-weight: 600;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.75);
+  margin-bottom: 1rem;
+}
+
+.hero .btn-primary {
+  background: var(--pi-primary);
+  border-color: var(--pi-primary);
+  font-weight: 600;
+  box-shadow: 0 12px 30px rgba(37, 99, 235, 0.35);
+}
+
+.hero .btn-primary:hover {
+  background: var(--pi-primary-dark);
+  border-color: var(--pi-primary-dark);
+}
+
+.hero .btn-outline-light {
+  border-width: 2px;
+  font-weight: 600;
+}
+
+.section-spacer {
+  padding: 5rem 0;
+}
+
+.section-title {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-weight: 600;
+  color: var(--pi-primary);
+  margin-bottom: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.section-heading {
+  font-weight: 600;
+  color: var(--pi-dark);
+}
+
+.section-lead {
+  color: var(--pi-muted);
+  font-size: 1.05rem;
+}
+
+.equipment-card {
+  background: #ffffff;
+  border: none;
+  border-radius: 1.25rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.equipment-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 60px rgba(37, 99, 235, 0.2);
+}
+
+.equipment-thumb {
+  position: relative;
+  overflow: hidden;
+  height: 220px;
+}
+
+.equipment-thumb::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0) 30%, rgba(15, 23, 42, 0.35) 100%);
+}
+
+.equipment-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.equipment-card .card-body {
+  padding: 1.75rem;
+}
+
+.history-section {
+  background: #f5efe4;
+}
+
+.history-figure {
+  position: relative;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  box-shadow: 0 24px 64px rgba(124, 58, 237, 0.18);
+}
+
+.history-figure img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.instructor-photo-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.instructor-photo {
+  width: 240px;
+  height: 240px;
+  object-fit: cover;
+  border-radius: 50%;
+  border: 6px solid #ffffff;
+  box-shadow: 0 18px 40px rgba(37, 99, 235, 0.25);
+}
+
+.instructor-highlight {
+  background: rgba(37, 99, 235, 0.08);
+  border-radius: 0.85rem;
+  padding: 0.75rem 1rem;
+  font-weight: 500;
+  color: var(--pi-dark);
+}
+
+.instructor-highlight-icon {
+  font-size: 0.75rem;
+  color: var(--pi-primary);
+  margin-top: 0.35rem;
+}
+
+.timeline {
+  position: relative;
+  margin-left: 1rem;
+  padding-left: 2rem;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 0.5rem;
+  top: 0.25rem;
+  bottom: 0.25rem;
+  width: 3px;
+  background: linear-gradient(180deg, rgba(37, 99, 235, 0.15), rgba(37, 99, 235, 0.65));
+}
+
+.timeline-item {
+  position: relative;
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.timeline-item:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-marker {
+  position: absolute;
+  left: -2.2rem;
+  top: 0.4rem;
+  width: 16px;
+  height: 16px;
+  background: #ffffff;
+  border: 3px solid var(--pi-primary);
+  border-radius: 50%;
+  box-shadow: 0 0 0 6px rgba(37, 99, 235, 0.12);
+}
+
+.timeline-card {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem 1.75rem;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
+}
+
+.timeline-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.timeline-year {
+  font-weight: 600;
+  color: var(--pi-primary);
+  background: rgba(37, 99, 235, 0.12);
+  border-radius: 999px;
+  padding: 0.25rem 0.9rem;
+  font-size: 0.85rem;
+}
+
+.plan-card {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  padding: 2.25rem 1.75rem;
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.1);
+  border: 1px solid rgba(37, 99, 235, 0.08);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.plan-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 26px 60px rgba(37, 99, 235, 0.18);
+}
+
+.plan-card .price {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--pi-primary);
+}
+
+.schedule-table .card {
+  border-radius: 1.5rem;
+  border: none;
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.08);
+}
+
+.schedule-table table {
+  font-size: 0.95rem;
+}
+
+.accordion-item {
+  border: none;
+  border-radius: 1rem !important;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
+}
+
+.accordion-button {
+  font-weight: 600;
+  padding: 1.2rem 1.5rem;
+  border-radius: 1rem !important;
+}
+
+.accordion-button:focus {
+  border-color: rgba(37, 99, 235, 0.25);
+  box-shadow: 0 0 0 0.25rem rgba(37, 99, 235, 0.15);
+}
+
+.accordion-button:not(.collapsed) {
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--pi-primary);
+}
+
+.contact-card {
+  background: #ffffff;
+  border-radius: 1.75rem;
+  padding: 2.5rem;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.12);
+}
+
+.contact-card .form-control {
+  border-radius: 0.85rem;
+  padding: 0.75rem 1rem;
+  border-color: rgba(15, 23, 42, 0.12);
+}
+
+.contact-card .form-control:focus {
+  border-color: var(--pi-primary);
+  box-shadow: 0 0 0 0.2rem rgba(37, 99, 235, 0.15);
+}
+
+.contact-card .btn-primary {
+  padding: 0.85rem 2.5rem;
+  font-weight: 600;
+}
+
+.contact-card .alert {
+  border: none;
+  border-radius: 0.85rem;
+  padding: 0.85rem 1.1rem;
+}
+
+.contact-card .alert.success {
+  background: rgba(16, 185, 129, 0.15);
+  color: #047857;
+}
+
+.contact-card .alert.error {
+  background: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
+}
+
+.contact-details a {
+  color: var(--pi-primary);
+  font-weight: 600;
+}
+
+.map-responsive iframe {
+  border: 0;
+  border-radius: 1.5rem;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.1);
+}
+
+.footer {
+  background: #020617;
+  color: #e2e8f0;
+  padding: 4rem 0 2rem;
+  position: relative;
+}
+
+.footer .brand img {
+  height: 48px;
+  width: auto;
+  margin-bottom: 1rem;
+}
+
+.footer h5 {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.footer a {
+  color: #e2e8f0;
+}
+
+.footer a:hover {
+  color: var(--pi-primary);
+}
+
+.footer .social-links a {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(148, 163, 184, 0.15);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.footer .social-links a:hover {
+  transform: translateY(-3px);
+  background: var(--pi-primary);
+}
+
+.bottom-bar {
+  border-top: 1px solid rgba(148, 163, 184, 0.15);
+  padding-top: 1.5rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.floating-whatsapp {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 1050;
+}
+
+.floating-whatsapp .btn {
+  border-radius: 999px;
+  padding: 0.9rem 1.6rem;
+  font-weight: 600;
+  box-shadow: 0 16px 30px rgba(34, 197, 94, 0.35);
+}
+
+@media (max-width: 767.98px) {
+  .hero .container {
+    padding: 5rem 1.5rem;
+  }
+
+  .timeline {
+    margin-left: 0;
+    padding-left: 1.5rem;
+  }
+
+  .timeline-marker {
+    left: -1.7rem;
+  }
+
+  .plan-card {
+    padding: 1.75rem 1.5rem;
+  }
+
+  .contact-card {
+    padding: 2rem 1.5rem;
+  }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const navbar = document.querySelector('.navbar');
+  const updateNavbarState = () => {
+    if (!navbar) return;
+    if (window.scrollY > 50) {
+      navbar.classList.add('navbar-scrolled');
+    } else {
+      navbar.classList.remove('navbar-scrolled');
+    }
+  };
+
+  updateNavbarState();
+  document.addEventListener('scroll', updateNavbarState);
+
+  const yearHolder = document.querySelector('[data-current-year]');
+  if (yearHolder) {
+    yearHolder.textContent = new Date().getFullYear().toString();
+  }
+});

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,23 @@
+<?php
+session_start();
+
+// Database configuration
+define('DB_HOST', getenv('DB_HOST') ?: 'localhost');
+define('DB_NAME', getenv('DB_NAME') ?: 'pistudiopilates');
+define('DB_USER', getenv('DB_USER') ?: 'root');
+define('DB_PASS', getenv('DB_PASS') ?: '');
+
+// Application paths
+$baseUrl = rtrim(getenv('BASE_URL') ?: '/', '/') . '/';
+define('BASE_URL', $baseUrl);
+define('ASSET_URL', BASE_URL . 'assets/');
+define('PUBLIC_PATH', dirname(__DIR__) . '/public/');
+define('UPLOAD_DIR', dirname(__DIR__) . '/assets/img/uploads/');
+define('UPLOAD_URL', ASSET_URL . 'img/uploads/');
+define('PLACEHOLDER_IMG', 'assets/img/placeholder.jpg');
+
+if (!is_dir(UPLOAD_DIR)) {
+    mkdir(UPLOAD_DIR, 0755, true);
+}
+
+require_once dirname(__DIR__) . '/functions/functions.php';

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -1,0 +1,227 @@
+<?php
+function getPDO(): PDO
+{
+    static $pdo = null;
+    if ($pdo === null) {
+        $dsn = 'mysql:host=' . DB_HOST . ';dbname=' . DB_NAME . ';charset=utf8mb4';
+        $options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ];
+        try {
+            $pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
+        } catch (PDOException $e) {
+            http_response_code(500);
+            echo 'Veritabanı bağlantı hatası: ' . htmlspecialchars($e->getMessage());
+            exit;
+        }
+    }
+    return $pdo;
+}
+
+function fetchOne(string $query, array $params = []): ?array
+{
+    $stmt = getPDO()->prepare($query);
+    $stmt->execute($params);
+    $result = $stmt->fetch();
+    return $result !== false ? $result : null;
+}
+
+function fetchAll(string $query, array $params = []): array
+{
+    $stmt = getPDO()->prepare($query);
+    $stmt->execute($params);
+    return $stmt->fetchAll();
+}
+
+function executeQuery(string $query, array $params = []): bool
+{
+    $stmt = getPDO()->prepare($query);
+    return $stmt->execute($params);
+}
+
+function isLoggedIn(): bool
+{
+    return isset($_SESSION['user_id']);
+}
+
+function requireLogin(): void
+{
+    if (!isLoggedIn()) {
+        header('Location: login.php');
+        exit;
+    }
+}
+
+function setFlash(string $key, $message): void
+{
+    $_SESSION['flash'][$key] = $message;
+}
+
+function getFlash(string $key)
+{
+    if (!empty($_SESSION['flash'][$key])) {
+        $message = $_SESSION['flash'][$key];
+        unset($_SESSION['flash'][$key]);
+        return $message;
+    }
+    return null;
+}
+
+function sanitizeFileName(string $filename): string
+{
+    $clean = preg_replace('/[^A-Za-z0-9\.\-_]/', '_', $filename);
+    return $clean ?: 'image_' . time();
+}
+
+function handleImageUpload(array $file, ?string $existing = null): ?string
+{
+    if (!isset($file['tmp_name']) || $file['error'] !== UPLOAD_ERR_OK) {
+        return $existing;
+    }
+
+    $ext = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+    if (!in_array($ext, ['jpg', 'jpeg', 'png', 'gif', 'webp'], true)) {
+        throw new RuntimeException('Desteklenmeyen dosya formatı.');
+    }
+
+    $filename = sanitizeFileName(pathinfo($file['name'], PATHINFO_FILENAME)) . '_' . time() . '.' . $ext;
+    $destination = UPLOAD_DIR . $filename;
+    if (!move_uploaded_file($file['tmp_name'], $destination)) {
+        throw new RuntimeException('Dosya yüklenemedi.');
+    }
+
+    if ($existing && $existing !== $filename) {
+        $existingPath = UPLOAD_DIR . ltrim($existing, '/');
+        if (file_exists($existingPath)) {
+            @unlink($existingPath);
+        }
+    }
+
+    return $filename;
+}
+
+function csrfToken(): string
+{
+    if (empty($_SESSION['csrf_token'])) {
+        $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION['csrf_token'];
+}
+
+function validateCsrf(string $token): void
+{
+    if (empty($_SESSION['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $token)) {
+        http_response_code(400);
+        exit('Geçersiz CSRF token.');
+    }
+}
+
+function img_path_or_fallback(?string $path): string
+{
+    $placeholder = PLACEHOLDER_IMG;
+
+    if ($path === null || $path === '') {
+        return $placeholder;
+    }
+
+    if (preg_match('/^https?:\/\//i', $path)) {
+        return $path;
+    }
+
+    $normalized = ltrim($path, '/');
+    $fullPath = dirname(__DIR__) . '/' . $normalized;
+
+    if (is_file($fullPath)) {
+        return $normalized;
+    }
+
+    return $placeholder;
+}
+
+function media_url(?string $path, ?string $fallback = null): string
+{
+    $candidate = $path ?? $fallback ?? PLACEHOLDER_IMG;
+
+    if (preg_match('/^https?:\/\//i', $candidate)) {
+        return $candidate;
+    }
+
+    $normalized = ltrim($candidate, '/');
+
+    if (str_starts_with($normalized, 'assets/')) {
+        $assetPath = img_path_or_fallback($candidate);
+
+        if (preg_match('/^https?:\/\//i', $assetPath)) {
+            return $assetPath;
+        }
+
+        return BASE_URL . ltrim($assetPath, '/');
+    }
+
+    return UPLOAD_URL . ltrim($normalized, '/');
+}
+
+function get_settings(): array
+{
+    if (!array_key_exists('__settings_cache', $GLOBALS) || $GLOBALS['__settings_cache'] === null) {
+        $GLOBALS['__settings_cache'] = fetchOne('SELECT * FROM settings LIMIT 1') ?: [];
+    }
+
+    return $GLOBALS['__settings_cache'];
+}
+
+function refresh_settings(): void
+{
+    $GLOBALS['__settings_cache'] = null;
+}
+
+function setting(string $key, $default = null)
+{
+    $settings = get_settings();
+    return $settings[$key] ?? $default;
+}
+
+function format_time(string $time): string
+{
+    return substr($time, 0, 5);
+}
+
+function send_contact_mail(string $name, string $email, string $phone, string $preference, string $message): void
+{
+    $to = setting('contact_email', 'info@pistudiopilates.com');
+    $subject = 'Pi Studio Pilates İletişim Formu';
+    $body = "Ad Soyad: {$name}\nE-posta: {$email}\nTelefon: {$phone}\nDers Tercihi: {$preference}\n\nMesaj:\n{$message}";
+    $headers = 'From: ' . $to . "\r\n" . 'Reply-To: ' . $email . "\r\n";
+    @mail($to, $subject, $body, $headers);
+}
+
+function whatsapp_link(?string $number): ?string
+{
+    if (!$number) {
+        return null;
+    }
+
+    $digits = preg_replace('/\D+/', '', $number);
+    if ($digits === '') {
+        return null;
+    }
+
+    if (str_starts_with($digits, '00')) {
+        $digits = substr($digits, 2) ?: '';
+    }
+
+    if ($digits === '') {
+        return null;
+    }
+
+    if ($digits[0] === '0') {
+        $digits = ltrim($digits, '0');
+        if ($digits === '') {
+            return null;
+        }
+        $digits = '90' . $digits;
+    }
+
+    return 'https://wa.me/' . $digits;
+}

--- a/pistudio.sql
+++ b/pistudio.sql
@@ -1,0 +1,179 @@
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role VARCHAR(50) NOT NULL DEFAULT 'admin',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+REPLACE INTO users (id, email, password, role) VALUES
+(1, 'pinar@pistudiopilates.com', '$2y$12$FyNfSGYn9XVqC.IVVomureQ5UQorHB4y40LSLLv/V7bkmF1Sxh9ye', 'admin');
+
+CREATE TABLE IF NOT EXISTS settings (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    site_name VARCHAR(150) NOT NULL,
+    logo VARCHAR(255) DEFAULT NULL,
+    language VARCHAR(10) NOT NULL DEFAULT 'tr',
+    contact_email VARCHAR(255) DEFAULT NULL,
+    contact_phone VARCHAR(120) DEFAULT NULL,
+    whatsapp_number VARCHAR(120) DEFAULT NULL,
+    instagram_url VARCHAR(255) DEFAULT NULL,
+    address VARCHAR(255) DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+REPLACE INTO settings (id, site_name, logo, language, contact_email, contact_phone, whatsapp_number, instagram_url, address) VALUES
+(1, 'Pi Studio Pilates', NULL, 'tr', 'info@pistudiopilates.com', '+90 530 111 22 33', '+90 530 111 22 33', 'https://www.instagram.com/pistudiopilates', 'Bağdat Caddesi No:123, İstanbul');
+
+CREATE TABLE IF NOT EXISTS hero (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    subtitle TEXT,
+    cta_primary_text VARCHAR(120),
+    cta_secondary_text VARCHAR(120),
+    cta_primary_link VARCHAR(255),
+    cta_secondary_link VARCHAR(255),
+    background_media VARCHAR(255),
+    address VARCHAR(255),
+    map_embed TEXT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+REPLACE INTO hero (id, title, subtitle, cta_primary_text, cta_secondary_text, cta_primary_link, cta_secondary_link, address, map_embed, background_media) VALUES
+(1, 'Pi Studio Pilates', 'Vücudunu güçlendir, nefesinle ak.', 'Deneme Dersi Al', 'Ders Programı', '#contact', '#schedule', 'Bağdat Caddesi No:123, İstanbul', '', 'assets/img/hero-bg.jpg');
+
+CREATE TABLE IF NOT EXISTS about_pilates (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    content TEXT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+REPLACE INTO about_pilates (id, content) VALUES
+(1, 'Pilates; nefes, kontrol ve core gücünü temel alan kapsamlı bir zihin-beden pratiğidir. Doğru nefes ve hizalanma ile vücudu güçlendirirken zihinsel farkındalığı artırır.');
+
+CREATE TABLE IF NOT EXISTS history (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    content TEXT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+REPLACE INTO history (id, content) VALUES
+(1, '20. yüzyılın başında Joseph Pilates tarafından geliştirilen kontroloji, modern pilates pratiğinin temelini oluşturur. Pi Studio Pilates bu mirası günümüz bilimiyle buluşturur.');
+
+CREATE TABLE IF NOT EXISTS instructor (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(120) NOT NULL,
+    bio TEXT,
+    highlights TEXT,
+    photo VARCHAR(255)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+REPLACE INTO instructor (id, name, bio, highlights, photo) VALUES
+(1, 'Pınar Sarı Koçak', 'Pınar Sarı Koçak, hareket anatomi bilgisi ve kişiye özel pilates yaklaşımıyla bedeninizi yeniden keşfetmenizi sağlar.', 'Mat Pilates\nReformer Pilates\nRehabilitasyon odaklı programlama\nPrenatal & Postnatal destek', 'assets/img/pinar.jpg');
+
+CREATE TABLE IF NOT EXISTS equipments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(120) NOT NULL,
+    description TEXT,
+    more_info TEXT,
+    img VARCHAR(255),
+    sort_order INT DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+TRUNCATE TABLE equipments;
+
+INSERT INTO equipments (title, description, more_info, img, sort_order) VALUES
+('Mat Pilates', 'Temel pilates prensipleri ve nefes eşliğinde güçlenme.', 'Mat derslerinde core stabilizasyonu, mobilite ve nefes teknikleri üzerinde çalışılır.', 'assets/img/equip-mat.jpg', 1),
+('Reformer', 'Dinamik yay sistemi ile kişiye özel direnç.', 'Reformer derslerinde kas kuvveti, esneklik ve postür dengesi hedeflenir.', 'assets/img/equip-reformer.jpg', 2),
+('Tower', 'Dikey yay sistemi ile kontrollü direnç.', 'Tower ekipmanı, reformer ve cadillac prensiplerinin birleşimini sunar.', 'assets/img/equip-tower.jpg', 3),
+('Cadillac', 'Çok yönlü egzersiz seçenekleri sunar.', 'Cadillac ile kuvvet, esneklik ve koordinasyon birlikte geliştirilir.', 'assets/img/equip-cadillac.jpg', 4),
+('Chair', 'Denge ve güç odaklı kompakt ekipman.', 'Chair egzersizleri özellikle core ve alt beden stabilitesini artırır.', 'assets/img/equip-chair.jpg', 5),
+('Barrel', 'Omurga mobilitesi ve esneklik için ideal.', 'Barrel dersleri postürü iyileştirir ve omurga esnekliğini destekler.', 'assets/img/equip-barrel.jpg', 6);
+
+CREATE TABLE IF NOT EXISTS trainings (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(200) NOT NULL,
+    year VARCHAR(40),
+    description TEXT,
+    img VARCHAR(255),
+    sort_order INT DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+TRUNCATE TABLE trainings;
+
+INSERT INTO trainings (title, year, description, img, sort_order) VALUES
+('Balanced Body Mat Sertifikası', '2016', 'Kapsamlı mat pilates eğitimi ve anatomi modülleri.', NULL, 1),
+('Balanced Body Reformer Sertifikası', '2017', 'Dinamik reformer ders planlaması ve progresyonlar.', NULL, 2),
+('Hamilelik ve Doğum Sonrası Pilates Uzmanlığı', '2018', 'Prenatal ve postnatal süreçler için güvenli hareket programları.', NULL, 3);
+
+CREATE TABLE IF NOT EXISTS plans (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(120) NOT NULL,
+    price VARCHAR(120) NOT NULL,
+    description TEXT,
+    sort_order INT DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+TRUNCATE TABLE plans;
+
+INSERT INTO plans (title, price, description, sort_order) VALUES
+('Deneme Dersi', '₺750', 'Stüdyomuzu ve eğitmenimizi deneyimleyin.', 1),
+('Aylık 4 Ders', '₺2.400', 'Haftada bir bireysel veya ikili seans.', 2),
+('Aylık 8 Ders', '₺4.400', 'Haftada iki seans ile düzenli gelişim.', 3),
+('Kişiye Özel Program', 'Teklif Üzerine', 'Rehabilitasyon ve özel hedefler için tasarlanır.', 4);
+
+CREATE TABLE IF NOT EXISTS schedule_entries (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    day_order TINYINT NOT NULL,
+    start_time TIME NOT NULL,
+    class_type VARCHAR(120) NOT NULL,
+    level VARCHAR(120)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+TRUNCATE TABLE schedule_entries;
+
+INSERT INTO schedule_entries (day_order, start_time, class_type, level) VALUES
+(1, '09:00:00', 'Mat Grup', 'Tüm seviyeler'),
+(3, '18:30:00', 'Reformer İkili', 'Orta seviye'),
+(5, '11:00:00', 'Birebir Reformer', 'Kişiye özel');
+
+CREATE TABLE IF NOT EXISTS faq (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    question VARCHAR(255) NOT NULL,
+    answer TEXT,
+    sort_order INT DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+TRUNCATE TABLE faq;
+
+INSERT INTO faq (question, answer, sort_order) VALUES
+('İptal politikası nedir?', 'Seanslar 12 saat öncesine kadar ücretsiz iptal edilebilir.', 1),
+('Derslere gelirken ne giymeliyim?', 'Rahat, esnek kıyafetler ve kaymaz çoraplar önerilir.', 2),
+('Sağlık beyanı gerekli mi?', 'İlk dersinizde kısa bir sağlık formu doldurmanızı rica ederiz.', 3);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(120) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    phone VARCHAR(60),
+    preference VARCHAR(120),
+    message TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS footer_links (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    label VARCHAR(120) NOT NULL,
+    url VARCHAR(255) NOT NULL,
+    target VARCHAR(20) DEFAULT '_self',
+    position INT DEFAULT 0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+TRUNCATE TABLE footer_links;
+
+INSERT INTO footer_links (label, url, target, position) VALUES
+('Impressum', '#', '_self', 1),
+('Datenschutzerklärung', '#', '_self', 2);
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,439 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+
+$settings = get_settings();
+$hero = fetchOne('SELECT * FROM hero LIMIT 1');
+$pilates = fetchOne('SELECT * FROM about_pilates LIMIT 1');
+$history = fetchOne('SELECT * FROM history LIMIT 1');
+$instructor = fetchOne('SELECT * FROM instructor LIMIT 1');
+$trainings = fetchAll('SELECT * FROM trainings ORDER BY sort_order, id');
+$equipments = fetchAll('SELECT * FROM equipments ORDER BY sort_order, id');
+$plans = fetchAll('SELECT * FROM plans ORDER BY sort_order, id');
+$schedule = fetchAll('SELECT * FROM schedule_entries ORDER BY day_order, start_time');
+$faq = fetchAll('SELECT * FROM faq ORDER BY sort_order, id');
+$footerLinks = fetchAll('SELECT * FROM footer_links ORDER BY position ASC');
+
+$siteName = setting('site_name', 'Pi Studio Pilates');
+$siteLanguage = setting('language', 'tr');
+$logoPath = setting('logo');
+$logoUrl = $logoPath ? media_url($logoPath) : null;
+$tagline = $hero['subtitle'] ?? 'Vücudunu güçlendir, nefesinle ak.';
+$contactEmail = setting('contact_email', 'info@pistudiopilates.com');
+$contactPhone = setting('contact_phone', '+90 530 111 22 33');
+$instagramUrl = setting('instagram_url', 'https://www.instagram.com');
+$whatsappNumber = setting('whatsapp_number', '+90 530 111 22 33');
+$address = $hero['address'] ?? setting('address', 'Bağdat Caddesi No:123, İstanbul');
+$whatsappLink = whatsapp_link($whatsappNumber) ?: 'https://wa.me/905301112233';
+
+$heroBackground = media_url($hero['background_media'] ?? null, 'assets/img/hero-bg.jpg');
+$historyImage = media_url($history['image'] ?? null, 'assets/img/history.jpg');
+$instructorPhoto = media_url($instructor['photo'] ?? null, 'assets/img/pinar.jpg');
+
+function dayLabel(int $dayOrder): string
+{
+    $days = [1 => 'Pazartesi', 2 => 'Salı', 3 => 'Çarşamba', 4 => 'Perşembe', 5 => 'Cuma', 6 => 'Cumartesi', 7 => 'Pazar'];
+    return $days[$dayOrder] ?? '';
+}
+
+function equipmentImage(array $equipment): string
+{
+    return media_url($equipment['img'] ?? null, 'assets/img/placeholder.jpg');
+}
+?>
+<!DOCTYPE html>
+<html lang="<?= htmlspecialchars($siteLanguage); ?>">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= htmlspecialchars($hero['title'] ?? $siteName); ?></title>
+    <meta name="description" content="<?= htmlspecialchars($tagline); ?>">
+    <meta property="og:title" content="<?= htmlspecialchars($hero['title'] ?? $siteName); ?>">
+    <meta property="og:description" content="<?= htmlspecialchars($tagline); ?>">
+    <meta property="og:image" content="<?= htmlspecialchars(media_url($hero['background_media'] ?? null)); ?>">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="<?= ASSET_URL ?>css/style.css">
+</head>
+<body id="top">
+<nav class="navbar navbar-expand-lg fixed-top navbar-light">
+    <div class="container">
+        <a class="navbar-brand d-flex align-items-center gap-2" href="#top">
+            <?php if ($logoUrl): ?>
+                <img src="<?= htmlspecialchars($logoUrl); ?>" alt="<?= htmlspecialchars($siteName); ?>">
+            <?php endif; ?>
+            <span><?= htmlspecialchars($siteName); ?></span>
+        </a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#primaryNav" aria-controls="primaryNav" aria-expanded="false" aria-label="Menüyü Aç">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="primaryNav">
+            <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+                <li class="nav-item"><a class="nav-link" href="#about">Pilates Nedir?</a></li>
+                <li class="nav-item"><a class="nav-link" href="#equipments">Ekipmanlar</a></li>
+                <li class="nav-item"><a class="nav-link" href="#history">Tarihçe</a></li>
+                <li class="nav-item"><a class="nav-link" href="#instructor">Pınar Sarı Koçak</a></li>
+                <li class="nav-item"><a class="nav-link" href="#trainings">Eğitimler</a></li>
+                <li class="nav-item"><a class="nav-link" href="#plans">Dersler & Üyelik</a></li>
+                <li class="nav-item"><a class="nav-link" href="#faq">S.S.S.</a></li>
+                <li class="nav-item"><a class="nav-link" href="#contact">İletişim</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+
+<header class="hero" style="--hero-image: url('<?= htmlspecialchars($heroBackground); ?>');">
+    <div class="hero-overlay"></div>
+    <div class="container position-relative text-center text-white">
+        <span class="hero-kicker">Pi Studio Pilates</span>
+        <h1 class="display-4 fw-bold mb-3"><?= htmlspecialchars($hero['title'] ?? $siteName); ?></h1>
+        <p class="lead mx-auto mb-4 col-lg-7"><?= nl2br(htmlspecialchars($tagline)); ?></p>
+        <div class="d-flex flex-column flex-md-row align-items-center justify-content-center gap-3">
+            <a class="btn btn-primary btn-lg px-4" href="<?= htmlspecialchars($hero['cta_primary_link'] ?? '#contact'); ?>"><?= htmlspecialchars($hero['cta_primary_text'] ?? 'Deneme Dersi Al'); ?></a>
+            <a class="btn btn-outline-light btn-lg px-4" href="<?= htmlspecialchars($hero['cta_secondary_link'] ?? '#schedule'); ?>"><?= htmlspecialchars($hero['cta_secondary_text'] ?? 'Ders Programı'); ?></a>
+        </div>
+    </div>
+</header>
+
+<main>
+    <section id="about" class="section-spacer bg-white">
+        <div class="container">
+            <div class="row justify-content-center text-center">
+                <div class="col-lg-10">
+                    <p class="section-title">Pilates Nedir?</p>
+                    <h2 class="section-heading mb-3">Nefes, Kontrol ve Core Gücü</h2>
+                    <p class="section-lead"><?= nl2br(htmlspecialchars($pilates['content'] ?? 'Pilates; nefes, kontrol ve core gücünü temel alan kapsamlı bir zihin-beden pratiğidir. Doğru nefes ve hizalanma ile bedeninizi yeniden keşfedin.')); ?></p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="equipments" class="section-spacer bg-light">
+        <div class="container">
+            <div class="row align-items-center mb-4">
+                <div class="col-lg-7">
+                    <p class="section-title">Ekipmanlar</p>
+                    <h2 class="section-heading mb-3">Stüdyomuzdaki Profesyonel Pilates Ekipmanları</h2>
+                </div>
+                <div class="col-lg-5 text-lg-end text-muted">
+                    <p class="section-lead mb-0">Her öğrencimiz için özel tasarlanan programlarla Mat, Reformer, Tower, Cadillac, Chair ve Barrel ekipmanları kullanıyoruz.</p>
+                </div>
+            </div>
+            <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4">
+                <?php foreach ($equipments as $equipment): ?>
+                    <div class="col">
+                        <article class="equipment-card h-100">
+                            <div class="equipment-thumb">
+                                <img src="<?= htmlspecialchars(equipmentImage($equipment)); ?>" alt="<?= htmlspecialchars($equipment['title']); ?>">
+                            </div>
+                            <div class="card-body d-flex flex-column">
+                                <h3 class="h5 mb-2"><?= htmlspecialchars($equipment['title']); ?></h3>
+                                <p class="flex-grow-1 mb-3"><?= nl2br(htmlspecialchars($equipment['description'])); ?></p>
+                                <?php if (!empty($equipment['more_info'])): ?>
+                                    <button class="btn btn-outline-primary mt-auto" data-bs-toggle="modal" data-bs-target="#equipmentModal<?= (int)$equipment['id']; ?>">Daha Fazla</button>
+                                <?php endif; ?>
+                            </div>
+                        </article>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </section>
+
+    <section id="history" class="section-spacer history-section">
+        <div class="container">
+            <div class="row g-5 align-items-center">
+                <div class="col-lg-5">
+                    <div class="history-figure">
+                        <img src="<?= htmlspecialchars($historyImage); ?>" alt="Joseph Pilates">
+                    </div>
+                </div>
+                <div class="col-lg-7">
+                    <p class="section-title">Kısaca Tarihçe</p>
+                    <h2 class="section-heading mb-3">Joseph Pilates&#39;in Kontroloji Mirası</h2>
+                    <p class="section-lead"><?= nl2br(htmlspecialchars($history['content'] ?? '20. yüzyılın başında Joseph Pilates tarafından geliştirilen kontroloji, modern pilates pratiğinin temelini oluşturur. Pi Studio Pilates bu mirası günümüz bilimiyle buluşturur.')); ?></p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="instructor" class="section-spacer bg-light">
+        <div class="container">
+            <div class="row g-5 align-items-center">
+                <div class="col-lg-5">
+                    <div class="instructor-photo-wrapper">
+                        <img src="<?= htmlspecialchars($instructorPhoto); ?>" class="instructor-photo" alt="Pınar Sarı Koçak">
+                    </div>
+                </div>
+                <div class="col-lg-7">
+                    <p class="section-title">Eğitmen</p>
+                    <h2 class="section-heading mb-3">Pınar Sarı Koçak Kimdir?</h2>
+                    <p class="section-lead mb-4"><?= nl2br(htmlspecialchars($instructor['bio'] ?? 'Pınar Sarı Koçak, hareket anatomi bilgisi ve kişiye özel pilates yaklaşımıyla bedeninizi yeniden keşfetmenizi sağlar.')); ?></p>
+                    <?php if (!empty($instructor['highlights'])): ?>
+                        <ul class="instructor-highlights list-unstyled row row-cols-1 row-cols-sm-2 g-3 mb-0">
+                            <?php foreach (explode("\n", $instructor['highlights']) as $highlight): ?>
+                                <?php $trimmed = trim($highlight); ?>
+                                <?php if ($trimmed === '') { continue; } ?>
+                                <li class="col">
+                                    <div class="instructor-highlight d-flex align-items-start gap-2">
+                                        <span class="instructor-highlight-icon" aria-hidden="true">&#9679;</span>
+                                        <span><?= htmlspecialchars($trimmed); ?></span>
+                                    </div>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="trainings" class="section-spacer bg-white">
+        <div class="container">
+            <div class="row justify-content-center text-center mb-5">
+                <div class="col-lg-8">
+                    <p class="section-title">Eğitimler</p>
+                    <h2 class="section-heading mb-3">Sertifikalar ve Uzmanlıklar</h2>
+                    <p class="section-lead">Pınar Sarı Koçak&#39;ın tamamladığı ve devam eden eğitimler, öğrencilerimizin güvenli ve etkili bir deneyim yaşamasını sağlar.</p>
+                </div>
+            </div>
+            <div class="timeline">
+                <?php foreach ($trainings as $training): ?>
+                    <div class="timeline-item">
+                        <div class="timeline-marker"></div>
+                        <div class="timeline-card">
+                            <div class="timeline-header">
+                                <?php if (!empty($training['year'])): ?>
+                                    <span class="timeline-year"><?= htmlspecialchars($training['year']); ?></span>
+                                <?php endif; ?>
+                                <h3 class="h5 mb-1"><?= htmlspecialchars($training['title']); ?></h3>
+                            </div>
+                            <p class="mb-0"><?= nl2br(htmlspecialchars($training['description'])); ?></p>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </section>
+
+    <section id="plans" class="section-spacer bg-light">
+        <div class="container">
+            <div class="row justify-content-center text-center mb-5">
+                <div class="col-lg-8">
+                    <p class="section-title">Dersler &amp; Üyelik</p>
+                    <h2 class="section-heading mb-3">Size Uygun Pilates Paketi</h2>
+                    <p class="section-lead">Deneme dersinden kişiye özel programlara kadar esnek paket seçenekleri ile hedeflerinize odaklanın.</p>
+                </div>
+            </div>
+            <div class="row row-cols-1 row-cols-md-2 row-cols-xl-4 g-4">
+                <?php foreach ($plans as $plan): ?>
+                    <div class="col">
+                        <div class="plan-card h-100">
+                            <h3 class="h5 mb-2"><?= htmlspecialchars($plan['title']); ?></h3>
+                            <p class="price mb-3"><?= htmlspecialchars($plan['price']); ?></p>
+                            <p class="flex-grow-1 mb-4"><?= nl2br(htmlspecialchars($plan['description'])); ?></p>
+                            <a class="btn btn-outline-primary w-100" href="#contact">Bilgi Al</a>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+            <div id="schedule" class="schedule-table mt-5">
+                <div class="card p-4">
+                    <h3 class="h4 mb-4 text-center">Haftalık Ders Programı</h3>
+                    <div class="table-responsive">
+                        <table class="table align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th scope="col">Gün</th>
+                                    <th scope="col">Saat</th>
+                                    <th scope="col">Ders</th>
+                                    <th scope="col">Seviye</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php foreach ($schedule as $entry): ?>
+                                    <tr>
+                                        <td><?= htmlspecialchars(dayLabel((int)$entry['day_order'])); ?></td>
+                                        <td><?= htmlspecialchars(format_time($entry['start_time'])); ?></td>
+                                        <td><?= htmlspecialchars($entry['class_type']); ?></td>
+                                        <td><?= htmlspecialchars($entry['level']); ?></td>
+                                    </tr>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="faq" class="section-spacer bg-white">
+        <div class="container">
+            <div class="row justify-content-center text-center mb-5">
+                <div class="col-lg-8">
+                    <p class="section-title">S.S.S.</p>
+                    <h2 class="section-heading mb-3">Sık Sorulan Sorular</h2>
+                    <p class="section-lead">Ders öncesi aklınıza takılan konular için hızlı cevaplar.</p>
+                </div>
+            </div>
+            <div class="accordion" id="faqAccordion">
+                <?php foreach ($faq as $index => $item): ?>
+                    <?php $collapseId = 'faq-' . (int)$item['id']; ?>
+                    <div class="accordion-item mb-3">
+                        <h3 class="accordion-header" id="heading-<?= $collapseId; ?>">
+                            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-<?= $collapseId; ?>" aria-expanded="false" aria-controls="collapse-<?= $collapseId; ?>">
+                                <?= htmlspecialchars($item['question']); ?>
+                            </button>
+                        </h3>
+                        <div id="collapse-<?= $collapseId; ?>" class="accordion-collapse collapse" aria-labelledby="heading-<?= $collapseId; ?>" data-bs-parent="#faqAccordion">
+                            <div class="accordion-body">
+                                <?= nl2br(htmlspecialchars($item['answer'])); ?>
+                            </div>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </section>
+
+    <section id="contact" class="section-spacer bg-light">
+        <div class="container">
+            <div class="row g-5 align-items-start">
+                <div class="col-lg-7 order-lg-1 order-2">
+                    <div class="contact-card">
+                        <h3 class="h4 mb-4">Deneme Dersi Talep Formu</h3>
+                        <?php if ($notice = getFlash('contact_form')): ?>
+                            <?php $noticeType = is_array($notice) ? ($notice['type'] ?? 'success') : 'success'; ?>
+                            <?php $noticeMessage = is_array($notice) ? ($notice['message'] ?? '') : $notice; ?>
+                            <?php if ($noticeMessage): ?>
+                                <div class="alert <?= $noticeType === 'error' ? 'error' : 'success'; ?>"><?= htmlspecialchars($noticeMessage); ?></div>
+                            <?php endif; ?>
+                        <?php endif; ?>
+                        <form action="process_contact.php" method="post" class="row g-3">
+                            <input type="hidden" name="csrf_token" value="<?= csrfToken(); ?>">
+                            <div class="col-md-6">
+                                <label for="name" class="form-label">Ad Soyad</label>
+                                <input type="text" id="name" name="name" class="form-control" required>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="phone" class="form-label">Telefon</label>
+                                <input type="tel" id="phone" name="phone" class="form-control">
+                            </div>
+                            <div class="col-md-6">
+                                <label for="email" class="form-label">E-posta</label>
+                                <input type="email" id="email" name="email" class="form-control" required>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="preference" class="form-label">Ders Tercihi</label>
+                                <input type="text" id="preference" name="preference" class="form-control" placeholder="Birebir, ikili, grup...">
+                            </div>
+                            <div class="col-12">
+                                <label for="message" class="form-label">Mesajınız</label>
+                                <textarea id="message" name="message" rows="4" class="form-control" placeholder="Beklentilerinizi ve hedeflerinizi paylaşın..."></textarea>
+                            </div>
+                            <div class="col-12">
+                                <button type="submit" class="btn btn-primary btn-lg">Gönder</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+                <div class="col-lg-5 order-lg-2 order-1">
+                    <p class="section-title">İletişim</p>
+                    <h2 class="section-heading mb-3">Pi Studio Pilates&#39;e Ulaşın</h2>
+                    <p class="section-lead mb-4">Deneme dersi talepleriniz, paket sorularınız ve stüdyomuza dair merak ettikleriniz için bize ulaşın.</p>
+                    <div class="contact-details">
+                        <p><strong>Telefon:</strong> <a href="tel:<?= htmlspecialchars(preg_replace('/\s+/', '', $contactPhone)); ?>"><?= htmlspecialchars($contactPhone); ?></a></p>
+                        <p><strong>E-posta:</strong> <a href="mailto:<?= htmlspecialchars($contactEmail); ?>"><?= htmlspecialchars($contactEmail); ?></a></p>
+                        <p><strong>Adres:</strong> <?= htmlspecialchars($address); ?></p>
+                    </div>
+                    <div class="map-responsive mt-4">
+                        <?php
+                        $mapEmbed = $hero['map_embed'] ?? '';
+                        if ($mapEmbed && stripos($mapEmbed, '<iframe') !== false) {
+                            echo $mapEmbed;
+                        } else {
+                            $mapSrc = $mapEmbed ?: 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3010.715183116564!2d28.97953!3d41.015137!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x0!2zNDFsw4AwMCcwNi4xIk4gMjjCsDE5JzA2LjMiRQ!5e0!3m2!1str!2str!4v1700000000000';
+                            ?>
+                            <div class="ratio ratio-4x3">
+                                <iframe src="<?= htmlspecialchars($mapSrc); ?>" allowfullscreen loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+                            </div>
+                            <?php
+                        }
+                        ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</main>
+
+<footer class="footer">
+    <div class="container">
+        <div class="row g-4">
+            <div class="col-lg-4">
+                <div class="brand">
+                    <?php if ($logoUrl): ?>
+                        <img src="<?= htmlspecialchars($logoUrl); ?>" alt="<?= htmlspecialchars($siteName); ?>">
+                    <?php endif; ?>
+                    <p class="mb-2 fw-semibold text-white"><?= htmlspecialchars($siteName); ?></p>
+                    <p><?= htmlspecialchars($tagline); ?></p>
+                </div>
+            </div>
+            <div class="col-lg-4 col-md-6">
+                <h5>Menü</h5>
+                <ul class="list-unstyled d-grid gap-2">
+                    <li><a href="#about">Pilates Nedir?</a></li>
+                    <li><a href="#equipments">Ekipmanlar</a></li>
+                    <li><a href="#plans">Üyelik</a></li>
+                    <li><a href="#faq">S.S.S.</a></li>
+                    <li><a href="#contact">İletişim</a></li>
+                </ul>
+            </div>
+            <div class="col-lg-4 col-md-6">
+                <h5>Bağlantılar</h5>
+                <div class="d-flex align-items-center gap-3 mb-3 social-links">
+                    <a href="<?= htmlspecialchars($instagramUrl); ?>" aria-label="Instagram" target="_blank" rel="noopener">IG</a>
+                    <a href="<?= htmlspecialchars($whatsappLink); ?>" aria-label="WhatsApp" target="_blank" rel="noopener">WA</a>
+                </div>
+                <ul class="list-unstyled d-grid gap-2">
+                    <?php foreach ($footerLinks as $link): ?>
+                        <li><a href="<?= htmlspecialchars($link['url']); ?>" target="<?= $link['target'] === '_blank' ? '_blank' : '_self'; ?>" rel="<?= $link['target'] === '_blank' ? 'noopener' : 'nofollow'; ?>"><?= htmlspecialchars($link['label']); ?></a></li>
+                    <?php endforeach; ?>
+                </ul>
+            </div>
+        </div>
+        <div class="bottom-bar text-center mt-4">
+            <small>&copy; <span data-current-year></span> <?= htmlspecialchars($siteName); ?>. Tüm hakları saklıdır.</small>
+        </div>
+    </div>
+</footer>
+
+<div class="floating-whatsapp">
+    <a class="btn btn-success btn-lg d-flex align-items-center gap-2" href="<?= htmlspecialchars($whatsappLink); ?>" target="_blank" rel="noopener">
+        <span>WhatsApp</span>
+    </a>
+</div>
+
+<?php foreach ($equipments as $equipment): ?>
+    <?php if (!empty($equipment['more_info'])): ?>
+        <div class="modal fade" id="equipmentModal<?= (int)$equipment['id']; ?>" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title"><?= htmlspecialchars($equipment['title']); ?></h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Kapat"></button>
+                    </div>
+                    <div class="modal-body">
+                        <?= nl2br(htmlspecialchars($equipment['more_info'])); ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+    <?php endif; ?>
+<?php endforeach; ?>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+<script src="<?= ASSET_URL ?>js/main.js"></script>
+</body>
+</html>

--- a/public/process_contact.php
+++ b/public/process_contact.php
@@ -1,0 +1,41 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: index.php');
+    exit;
+}
+
+validateCsrf($_POST['csrf_token'] ?? '');
+
+$name = trim($_POST['name'] ?? '');
+$email = trim($_POST['email'] ?? '');
+$phone = trim($_POST['phone'] ?? '');
+$preference = trim($_POST['preference'] ?? '');
+$message = trim($_POST['message'] ?? '');
+
+if ($name === '' || $email === '') {
+    setFlash('contact_form', [
+        'type' => 'error',
+        'message' => 'Lütfen gerekli alanları doldurun.',
+    ]);
+    header('Location: index.php#contact');
+    exit;
+}
+
+executeQuery('INSERT INTO messages (name, email, phone, preference, message) VALUES (:name, :email, :phone, :preference, :message)', [
+    ':name' => $name,
+    ':email' => $email,
+    ':phone' => $phone,
+    ':preference' => $preference,
+    ':message' => $message,
+]);
+
+send_contact_mail($name, $email, $phone, $preference, $message);
+
+setFlash('contact_form', [
+    'type' => 'success',
+    'message' => 'Mesajınız alınmıştır. En kısa sürede size dönüş yapılacaktır.',
+]);
+header('Location: index.php#contact');
+exit;


### PR DESCRIPTION
## Summary
- replace the inline SVG placeholder with an assets path and add an `img_path_or_fallback` helper for missing files
- update the public site and SQL seed data to reference the required asset filenames while relying on the new fallback logic
- clarify in the README that image binaries are not stored in the repo and must be uploaded manually, including the uploads location

## Testing
- php -l config/config.php
- php -l functions/functions.php
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68dd2751c34c83249c6e1222aeb7a7a0